### PR TITLE
On2 perf & stale threshold data notices

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,23 @@ export default [
         },
     },
     {
+        files: ['scripts/**/*.mjs'],
+        languageOptions: {
+            globals: {
+                console: 'readonly',
+                process: 'readonly',
+            },
+        },
+    },
+    {
+        files: ['tests/threshold_staleness_check.test.mjs'],
+        languageOptions: {
+            globals: {
+                process: 'readonly',
+            },
+        },
+    },
+    {
         files: ['pwa/src/report/build.js', 'pwa/src/parse/payroll.js'],
         rules: {
             '@typescript-eslint/no-unused-vars': 'off',

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
     "name": "anonymous-payroll-reporter",
     "version": "3.9.0",
     "type": "module",
-    "private": true,
+    "private": false,
     "author": "bnjmnrsh",
     "license": "MIT",
     "description": "Payroll PDF Processor PWA and test/fixture tooling",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/FairToolsWork/anonymous-payroll-reporter"
+    },
     "scripts": {
         "fixtures:pdf": "./generate_fixtures/.venv/bin/python generate_fixtures/generate_pdf_fixtures.py",
         "fixtures:expected-pdf": "vitest run tests/utils/regenerate_expected_payslips.test.mjs",
@@ -24,6 +28,7 @@
         "test:report_calc": "vitest run tests/report_calculation.test.mjs",
         "test:all": "vitest run",
         "test:coverage": "vitest run --coverage",
+        "check:thresholds": "node scripts/check-threshold-staleness.mjs",
         "check:js": "tsc -p tsconfig.json",
         "jslint": "eslint .",
         "jslint:fix": "eslint . --fix",
@@ -33,7 +38,7 @@
         "precommit": "pnpm format && pnpm jslint && pnpm csslint && pnpm check:js && pnpm fixtures:check && pnpm fixtures:expected-pdf && pnpm fixtures:expected-excel && pnpm pwa:build && pnpm test:all",
         "prepare": "husky install",
         "pwa:dev": "vite",
-        "pwa:build": "vite build",
+        "pwa:build": "pnpm check:thresholds && vite build",
         "pwa:generate": "node node_modules/.pnpm/pwa-asset-generator@8.1.2/node_modules/pwa-asset-generator/dist/cli.js pwa/public/icons/icon.svg pwa/public/icons --scrape false --type png --padding \"12%\" --background \"#f4ebd4\" --manifest pwa/public/site.webmanifest --index pwa/index.html --path-override \"/icons\"",
         "cf:deploy": "wrangler deploy",
         "cf:deploy:build": "pnpm pwa:build && wrangler deploy",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "anonymous-payroll-reporter",
     "version": "3.9.0",
     "type": "module",
-    "private": false,
+    "private": true,
     "author": "bnjmnrsh",
     "license": "MIT",
     "description": "Payroll PDF Processor PWA and test/fixture tooling",

--- a/pwa/src/report/build.js
+++ b/pwa/src/report/build.js
@@ -19,7 +19,10 @@ import {
 } from './holiday_calculations.js'
 import {
     CONTRIBUTION_RECENCY_DAYS_THRESHOLD,
+    formatTaxYearLabelFromStartYear,
+    getTaxYearStartYearFromDate,
     getTaxYearThresholdsForContext,
+    resolveTaxYearThresholdsForContext,
     RULES_VERSION,
     THRESHOLDS_VERSION,
 } from './uk_thresholds.js'
@@ -61,7 +64,8 @@ const timing = /** @type {any} */ (globalThis).__payrollTiming || null
  * @typedef {{ workerType: string | null, typicalDays: number, statutoryHolidayDays: number | null, leaveYearStartMonth: number, payrollRunStartDate: string | null, pensionDefermentCommunicated?: boolean, pensionDefermentStartDate?: string | null, pensionDefermentEndDate?: string | null }} WorkerProfileContext
  * @typedef {{ flaggedCount: number, lowConfidenceCount: number, flaggedPeriods: string[] }} ValidationSummary
  * @typedef {{ dateRangeLabel: string, missingMonthsLabel: string, missingMonthsHtml: string, missingMonthsByYear: Record<string, string[]>, contributionMeta: ContributionMeta, validationSummary: ValidationSummary }} ReportStats
- * @typedef {{ entries: ReportEntry[], yearGroups: Map<string, YearEntries>, yearKeys: string[], contributionSummary: ContributionSummary | null, contributionMeta: ContributionMeta, reportGeneratedLabel: string, auditMetadata: { rulesVersion: string, thresholdsVersion: string }, missingMonths: { missingMonthsByYear: Record<string, string[]>, hasMissingMonths: boolean, missingMonthsLabel: string, missingMonthsHtml: string }, validationSummary: { flaggedEntries: ReportEntry[], lowConfidenceEntries: ReportEntry[], flaggedPeriods: string[], validationPill: string }, contributionTotals: { payrollEE: number, payrollER: number, payrollContribution: number, pensionEE: number | null, pensionER: number | null, reportedContribution: number | null, contributionDifference: number | null }, contributionRecency: { lastContributionLabel: string, daysSinceContribution: number | null, daysThreshold: number }, workerProfile: { workerType: string | null, typicalDays: number, statutoryHolidayDays: number | null, leaveYearStartMonth: number, payrollRunStartDate: string | null, pensionDefermentCommunicated?: boolean, pensionDefermentStartDate?: string | null, pensionDefermentEndDate?: string | null }, contractTypeMismatchWarning: string | null, leaveYearGroups: Map<string, YearEntries> }} ReportContext
+ * @typedef {{ reportRunDateIso: string, runTaxYearLabel: string | null, fallbackTaxYearLabels: string[], affectedPeriods: string[], hasRunTaxYearFallback: boolean }} ThresholdStalenessContext
+ * @typedef {{ entries: ReportEntry[], yearGroups: Map<string, YearEntries>, yearKeys: string[], contributionSummary: ContributionSummary | null, contributionMeta: ContributionMeta, reportGeneratedLabel: string, auditMetadata: { rulesVersion: string, thresholdsVersion: string }, thresholdStaleness: ThresholdStalenessContext, missingMonths: { missingMonthsByYear: Record<string, string[]>, hasMissingMonths: boolean, missingMonthsLabel: string, missingMonthsHtml: string }, validationSummary: { flaggedEntries: ReportEntry[], lowConfidenceEntries: ReportEntry[], flaggedPeriods: string[], validationPill: string }, contributionTotals: { payrollEE: number, payrollER: number, payrollContribution: number, pensionEE: number | null, pensionER: number | null, reportedContribution: number | null, contributionDifference: number | null }, contributionRecency: { lastContributionLabel: string, daysSinceContribution: number | null, daysThreshold: number }, workerProfile: { workerType: string | null, typicalDays: number, statutoryHolidayDays: number | null, leaveYearStartMonth: number, payrollRunStartDate: string | null, pensionDefermentCommunicated?: boolean, pensionDefermentStartDate?: string | null, pensionDefermentEndDate?: string | null }, contractTypeMismatchWarning: string | null, leaveYearGroups: Map<string, YearEntries> }} ReportContext
  */
 
 /**
@@ -422,6 +426,54 @@ export function buildReport(
                         totalGrossPay < thresholds.personalAllowanceMonthly
                     )
                 })
+
+                const runTaxYearStart =
+                    getTaxYearStartYearFromDate(reportRunDate)
+                const fallbackTaxYearStarts = new Set()
+                const fallbackPeriodsInRunTaxYear = /** @type {string[]} */ ([])
+
+                entries.forEach((entry) => {
+                    const resolution = resolveTaxYearThresholdsForContext(
+                        entry.parsedDate,
+                        entry.yearKey
+                    )
+                    if (resolution.status !== 'fallback-to-previous-tax-year') {
+                        return
+                    }
+                    if (
+                        runTaxYearStart === null ||
+                        resolution.taxYearStart !== runTaxYearStart
+                    ) {
+                        return
+                    }
+                    if (resolution.fallbackTaxYearStart !== null) {
+                        fallbackTaxYearStarts.add(
+                            resolution.fallbackTaxYearStart
+                        )
+                    }
+                    const periodLabel = entry.parsedDate
+                        ? formatDateLabel(entry.parsedDate)
+                        : entry.record.payrollDoc?.processDate?.date ||
+                          'Unknown'
+                    fallbackPeriodsInRunTaxYear.push(periodLabel)
+                })
+
+                const thresholdStaleness = {
+                    reportRunDateIso: reportRunDate.toISOString(),
+                    runTaxYearLabel:
+                        runTaxYearStart === null
+                            ? null
+                            : formatTaxYearLabelFromStartYear(runTaxYearStart),
+                    fallbackTaxYearLabels: Array.from(fallbackTaxYearStarts)
+                        .sort((a, b) => a - b)
+                        .map((yearStart) =>
+                            formatTaxYearLabelFromStartYear(yearStart)
+                        ),
+                    affectedPeriods: fallbackPeriodsInRunTaxYear,
+                    hasRunTaxYearFallback:
+                        fallbackPeriodsInRunTaxYear.length > 0,
+                }
+
                 const contributionTotalsResult = buildContributionTotals(
                     entries,
                     contributionSummary
@@ -441,6 +493,7 @@ export function buildReport(
                     missingMonths,
                     validationSummary,
                     hasLowPretaxPay,
+                    thresholdStaleness,
                     contributionTotalsResult,
                     daysThreshold,
                     contributionRecency,
@@ -456,6 +509,7 @@ export function buildReport(
             missingMonths,
             validationSummary,
             hasLowPretaxPay,
+            thresholdStaleness,
             contributionTotalsResult,
             daysThreshold,
             contributionRecency,
@@ -504,6 +558,7 @@ export function buildReport(
                     rulesVersion: RULES_VERSION,
                     thresholdsVersion: THRESHOLDS_VERSION,
                 },
+                thresholdStaleness,
                 contributionMeta,
                 missingMonths: missingMonthsResult,
                 validationSummary: validationSummaryResult,

--- a/pwa/src/report/build.js
+++ b/pwa/src/report/build.js
@@ -14,6 +14,7 @@ import {
 } from '../parse/parser_config.js'
 import { renderHtmlReport } from './html_export.js'
 import {
+    createHolidayReferenceRuntime,
     buildHolidayPayFlags,
     buildYearHolidayContext,
 } from './holiday_calculations.js'
@@ -209,11 +210,18 @@ export function buildReport(
             })
         })
 
+        /** @type {any} */
+        let holidayReferenceRuntime = null
         timeBuildPhase('buildReport.holidayFlags', () => {
-            buildHolidayPayFlags(entries)
+            holidayReferenceRuntime = createHolidayReferenceRuntime(entries)
+            buildHolidayPayFlags(entries, holidayReferenceRuntime)
         })
         timeBuildPhase('buildReport.holidayContext', () => {
-            buildYearHolidayContext(entries, workerProfile)
+            buildYearHolidayContext(
+                entries,
+                workerProfile,
+                holidayReferenceRuntime
+            )
         })
 
         let contractTypeMismatchWarning = null

--- a/pwa/src/report/build.js
+++ b/pwa/src/report/build.js
@@ -65,7 +65,7 @@ const timing = /** @type {any} */ (globalThis).__payrollTiming || null
  * @typedef {{ flaggedCount: number, lowConfidenceCount: number, flaggedPeriods: string[] }} ValidationSummary
  * @typedef {{ dateRangeLabel: string, missingMonthsLabel: string, missingMonthsHtml: string, missingMonthsByYear: Record<string, string[]>, contributionMeta: ContributionMeta, validationSummary: ValidationSummary }} ReportStats
  * @typedef {{ reportRunDateIso: string, runTaxYearLabel: string | null, fallbackTaxYearLabels: string[], affectedPeriods: string[], hasRunTaxYearFallback: boolean }} ThresholdStalenessContext
- * @typedef {{ entries: ReportEntry[], yearGroups: Map<string, YearEntries>, yearKeys: string[], contributionSummary: ContributionSummary | null, contributionMeta: ContributionMeta, reportGeneratedLabel: string, auditMetadata: { rulesVersion: string, thresholdsVersion: string }, thresholdStaleness: ThresholdStalenessContext, missingMonths: { missingMonthsByYear: Record<string, string[]>, hasMissingMonths: boolean, missingMonthsLabel: string, missingMonthsHtml: string }, validationSummary: { flaggedEntries: ReportEntry[], lowConfidenceEntries: ReportEntry[], flaggedPeriods: string[], validationPill: string }, contributionTotals: { payrollEE: number, payrollER: number, payrollContribution: number, pensionEE: number | null, pensionER: number | null, reportedContribution: number | null, contributionDifference: number | null }, contributionRecency: { lastContributionLabel: string, daysSinceContribution: number | null, daysThreshold: number }, workerProfile: { workerType: string | null, typicalDays: number, statutoryHolidayDays: number | null, leaveYearStartMonth: number, payrollRunStartDate: string | null, pensionDefermentCommunicated?: boolean, pensionDefermentStartDate?: string | null, pensionDefermentEndDate?: string | null }, contractTypeMismatchWarning: string | null, leaveYearGroups: Map<string, YearEntries> }} ReportContext
+ * @typedef {{ entries: ReportEntry[], yearGroups: Map<string, YearEntries>, yearKeys: string[], contributionSummary: ContributionSummary | null, contributionMeta: ContributionMeta, reportGeneratedLabel: string, auditMetadata: { rulesVersion: string, thresholdsVersion: string }, thresholdStaleness: ThresholdStalenessContext, missingMonths: { missingMonthsByYear: Record<string, string[]>, hasMissingMonths: boolean, missingMonthsLabel: string, missingMonthsHtml: string }, validationSummary: { flaggedEntries: ReportEntry[], lowConfidenceEntries: ReportEntry[], flaggedPeriods: string[], validationPill: string }, contributionTotals: { payrollEE: number, payrollER: number, payrollContribution: number, pensionEE: number | null, pensionER: number | null, reportedContribution: number | null, contributionDifference: number | null }, contributionRecency: { lastContributionLabel: string, daysSinceContribution: number | null, daysThreshold: number }, workerProfile: { workerType: string | null, typicalDays: number, statutoryHolidayDays: number | null, leaveYearStartMonth: number, payrollRunStartDate: string | null, pensionDefermentCommunicated?: boolean, pensionDefermentStartDate?: string | null, pensionDefermentEndDate?: string | null }, contractTypeMismatchWarning: string | null, leaveYearGroups: Map<string, YearEntries>, miscFootnotes: Array<{ type: string, dateLabel: string, yearKey: string, item: PayrollPayItem | PayrollMiscDeduction }> }} ReportContext
  */
 
 /**
@@ -378,12 +378,13 @@ export function buildReport(
                     dateRangeLabel: contributionRangeLabel,
                 }
                 const miscFootnotes =
-                    /** @type {Array<{ type: string, dateLabel: string, item: PayrollPayItem | PayrollMiscDeduction }>} */ (
+                    /** @type {Array<{ type: string, dateLabel: string, yearKey: string, item: PayrollPayItem | PayrollMiscDeduction }>} */ (
                         entries.reduce((/** @type {any[]} */ acc, entry) => {
                             const dateLabel = entry.parsedDate
                                 ? formatDateLabel(entry.parsedDate)
                                 : entry.record.payrollDoc?.processDate?.date ||
                                   'Unknown'
+                            const entryYearKey = entry.yearKey || ''
                             const miscPayments =
                                 entry.record.payrollDoc?.payments?.misc || []
                             const miscDeductions =
@@ -392,6 +393,7 @@ export function buildReport(
                                 acc.push({
                                     type: 'payment',
                                     dateLabel,
+                                    yearKey: entryYearKey,
                                     item,
                                 })
                             })
@@ -399,6 +401,7 @@ export function buildReport(
                                 acc.push({
                                     type: 'deduction',
                                     dateLabel,
+                                    yearKey: entryYearKey,
                                     item,
                                 })
                             })
@@ -572,6 +575,7 @@ export function buildReport(
                 leaveYearGroups: /** @type {Map<string, YearEntries>} */ (
                     leaveYearGroups
                 ),
+                miscFootnotes,
             }
             return {
                 html: renderHtmlReport(context, {

--- a/pwa/src/report/holiday_calculations.js
+++ b/pwa/src/report/holiday_calculations.js
@@ -360,6 +360,111 @@ export function getRollingReferenceCoverage(
 }
 
 /**
+ * @param {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, mixedMonthsIncluded: number }} coverage
+ * @returns {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, limitedData: boolean, mixedMonthsIncluded: number, confidence: ReferenceConfidence } | null}
+ */
+function buildRollingReferenceFromCoverage(coverage) {
+    if (coverage.periodsCounted < 3) {
+        return null
+    }
+    return {
+        totalBasicPay: coverage.totalBasicPay,
+        totalBasicHours: coverage.totalBasicHours,
+        totalWeeks: coverage.totalWeeks,
+        periodsCounted: coverage.periodsCounted,
+        limitedData: coverage.totalWeeks < 52,
+        mixedMonthsIncluded: coverage.mixedMonthsIncluded,
+        confidence: buildReferenceConfidence({
+            limitedData: coverage.totalWeeks < 52,
+            totalWeeks: coverage.totalWeeks,
+            mixedMonthsIncluded: coverage.mixedMonthsIncluded,
+        }),
+    }
+}
+
+/**
+ * @param {HolidayEntry[]} sortedEntries
+ * @param {HolidayEntry} targetEntry
+ * @param {{ pureOnly?: boolean }} [options]
+ * @returns {{ coverage: { totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, mixedMonthsIncluded: number, scannedEntries: number }, reference: { totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, limitedData: boolean, mixedMonthsIncluded: number, confidence: ReferenceConfidence } | null }}
+ */
+function buildRollingReferenceWithCoverage(
+    sortedEntries,
+    targetEntry,
+    options = {}
+) {
+    const timingEnabled = Boolean(timing?.enabled)
+    const startedAt = timingEnabled ? globalThis.performance.now() : 0
+    const pureOnly = Boolean(options.pureOnly)
+    const targetDate = targetEntry.parsedDate
+    if (!targetDate) {
+        if (timingEnabled) {
+            timing.increment('rollingReference.calls')
+            timing.increment('rollingReference.nullTargetDate')
+            timing.record(
+                'rollingReference.total',
+                globalThis.performance.now() - startedAt
+            )
+        }
+        return {
+            coverage: {
+                totalBasicPay: 0,
+                totalBasicHours: 0,
+                totalWeeks: 0,
+                periodsCounted: 0,
+                mixedMonthsIncluded: 0,
+                scannedEntries: 0,
+            },
+            reference: null,
+        }
+    }
+
+    const coverage = getRollingReferenceCoverage(sortedEntries, targetEntry, {
+        pureOnly,
+    })
+
+    if (timingEnabled) {
+        timing.increment('rollingReference.calls')
+        timing.increment(
+            'rollingReference.scannedEntries',
+            coverage.scannedEntries
+        )
+        timing.increment(
+            'rollingReference.periodsCounted',
+            coverage.periodsCounted
+        )
+        timing.recordMax(
+            'rollingReference.maxScannedEntries',
+            coverage.scannedEntries
+        )
+        timing.recordMax(
+            'rollingReference.maxPeriodsCounted',
+            coverage.periodsCounted
+        )
+        timing.increment(
+            'rollingReference.include.mixedMonth',
+            coverage.mixedMonthsIncluded
+        )
+    }
+
+    const reference = buildRollingReferenceFromCoverage(coverage)
+
+    if (timingEnabled) {
+        if (!reference) {
+            timing.increment('rollingReference.nullResult')
+        } else if (reference.limitedData) {
+            timing.increment('rollingReference.limitedData')
+        }
+        timing.record(
+            'rollingReference.total',
+            globalThis.performance.now() - startedAt
+        )
+    }
+
+    return { coverage, reference }
+}
+
+/**
  * @param {HolidayEntry[]} sortedEntries
  * @param {HolidayEntry} targetEntry
  * @returns {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, limitedData: boolean, mixedMonthsIncluded: number, confidence: ReferenceConfidence } | null}
@@ -437,77 +542,11 @@ export function buildRollingReference(
     targetEntry,
     options = {}
 ) {
-    const timingEnabled = Boolean(timing?.enabled)
-    const startedAt = timingEnabled ? globalThis.performance.now() : 0
-    const pureOnly = Boolean(options.pureOnly)
-    const targetDate = targetEntry.parsedDate
-    if (!targetDate) {
-        if (timingEnabled) {
-            timing.increment('rollingReference.calls')
-            timing.increment('rollingReference.nullTargetDate')
-            timing.record(
-                'rollingReference.total',
-                globalThis.performance.now() - startedAt
-            )
-        }
-        return null
-    }
-    const {
-        totalBasicPay,
-        totalBasicHours,
-        totalWeeks,
-        periodsCounted,
-        mixedMonthsIncluded,
-        scannedEntries,
-    } = getRollingReferenceCoverage(sortedEntries, targetEntry, {
-        pureOnly,
-    })
-
-    if (timingEnabled) {
-        timing.increment('rollingReference.calls')
-        timing.increment('rollingReference.scannedEntries', scannedEntries)
-        timing.increment('rollingReference.periodsCounted', periodsCounted)
-        timing.recordMax('rollingReference.maxScannedEntries', scannedEntries)
-        timing.recordMax('rollingReference.maxPeriodsCounted', periodsCounted)
-        timing.increment(
-            'rollingReference.include.mixedMonth',
-            mixedMonthsIncluded
-        )
-    }
-
-    if (periodsCounted < 3) {
-        if (timingEnabled) {
-            timing.increment('rollingReference.nullResult')
-            timing.record(
-                'rollingReference.total',
-                globalThis.performance.now() - startedAt
-            )
-        }
-        return null
-    }
-    const result = {
-        totalBasicPay,
-        totalBasicHours,
-        totalWeeks,
-        periodsCounted,
-        limitedData: totalWeeks < 52,
-        mixedMonthsIncluded,
-        confidence: buildReferenceConfidence({
-            limitedData: totalWeeks < 52,
-            totalWeeks,
-            mixedMonthsIncluded,
-        }),
-    }
-    if (timingEnabled) {
-        if (result.limitedData) {
-            timing.increment('rollingReference.limitedData')
-        }
-        timing.record(
-            'rollingReference.total',
-            globalThis.performance.now() - startedAt
-        )
-    }
-    return result
+    return buildRollingReferenceWithCoverage(
+        sortedEntries,
+        targetEntry,
+        options
+    ).reference
 }
 
 /**
@@ -573,23 +612,23 @@ export function buildHolidayPayFlags(entries) {
                   ? basicAmount / basicUnits
                   : null
 
-        const ref = buildRollingReference(sortedEntries, entry)
+        const { coverage, reference: ref } = buildRollingReferenceWithCoverage(
+            sortedEntries,
+            entry
+        )
         applyMixedMonthLowConfidence(entry, ref)
 
-        if (!ref && hasHolidayPayment(entry)) {
-            const coverage = getRollingReferenceCoverage(sortedEntries, entry)
-            if (coverage.periodsCounted < 3) {
-                entry.validation.lowConfidence = true
-                pushFlagIfMissing(entry, {
-                    id: 'holiday_reference_insufficient_history',
-                    severity: 'notice',
-                    label: formatFlagLabel(
-                        'holiday_reference_insufficient_history'
-                    ),
-                    ruleId: 'holiday_reference_insufficient_history',
-                    inputs: {},
-                })
-            }
+        if (!ref && coverage.periodsCounted < 3) {
+            entry.validation.lowConfidence = true
+            pushFlagIfMissing(entry, {
+                id: 'holiday_reference_insufficient_history',
+                severity: 'notice',
+                label: formatFlagLabel(
+                    'holiday_reference_insufficient_history'
+                ),
+                ruleId: 'holiday_reference_insufficient_history',
+                inputs: {},
+            })
         }
 
         const entryIsMixedMonthCandidate = isMixedMonthCandidate(entry)

--- a/pwa/src/report/holiday_calculations.js
+++ b/pwa/src/report/holiday_calculations.js
@@ -260,17 +260,74 @@ function getEntryMonthKey(entry) {
 }
 
 /**
- * Computes rolling-reference coverage for a target entry.
+ * @param {HolidayEntry[]} entries
+ * @returns {HolidayEntry[]}
+ */
+function sortHolidayEntries(entries) {
+    return [...entries].sort((a, b) => {
+        const aTime = a.parsedDate?.getTime() ?? 0
+        const bTime = b.parsedDate?.getTime() ?? 0
+        return aTime - bTime
+    })
+}
+
+/**
  * @param {HolidayEntry[]} sortedEntries
+ * @returns {any}
+ */
+function createHolidayReferenceRuntimeFromSortedEntries(sortedEntries) {
+    const referenceCache = new Map()
+    const pureReferenceCache = new Map()
+    const gateCache = new Map()
+
+    /** @type {any} */
+    const runtime = {
+        sortedEntries,
+        referenceCache,
+        pureReferenceCache,
+        gateCache,
+        /** @param {HolidayEntry} targetEntry */
+        getReferenceData(targetEntry) {
+            return getCachedRollingReferenceWithCoverage(
+                runtime,
+                targetEntry,
+                false
+            )
+        },
+        /** @param {HolidayEntry} targetEntry */
+        getPureReferenceData(targetEntry) {
+            return getCachedRollingReferenceWithCoverage(
+                runtime,
+                targetEntry,
+                true
+            )
+        },
+        /** @param {HolidayEntry} mixedEntry */
+        isGatePassingMixedMonth(mixedEntry) {
+            return getCachedGateDecision(runtime, mixedEntry)
+        },
+    }
+
+    return runtime
+}
+
+/**
+ * @param {HolidayEntry[]} entries
+ * @returns {any}
+ */
+export function createHolidayReferenceRuntime(entries) {
+    return createHolidayReferenceRuntimeFromSortedEntries(
+        sortHolidayEntries(entries)
+    )
+}
+
+/**
+ * @param {any} runtime
  * @param {HolidayEntry} targetEntry
  * @param {{ pureOnly?: boolean }} [options]
  * @returns {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, mixedMonthsIncluded: number, scannedEntries: number }}
  */
-export function getRollingReferenceCoverage(
-    sortedEntries,
-    targetEntry,
-    options = {}
-) {
+function computeRollingReferenceCoverage(runtime, targetEntry, options = {}) {
     const pureOnly = Boolean(options.pureOnly)
     const targetDate = targetEntry.parsedDate
     if (!targetDate) {
@@ -297,8 +354,8 @@ export function getRollingReferenceCoverage(
     /** @type {Set<string>} */
     const monthsSeen = new Set()
 
-    for (let i = sortedEntries.length - 1; i >= 0; i -= 1) {
-        const entry = sortedEntries[i]
+    for (let i = runtime.sortedEntries.length - 1; i >= 0; i -= 1) {
+        const entry = runtime.sortedEntries[i]
         scannedEntries += 1
         if (entry === targetEntry) {
             continue
@@ -325,7 +382,7 @@ export function getRollingReferenceCoverage(
         let countedAsMixedMonth = false
         if (isReferenceEligible(entry)) {
             shouldInclude = true
-        } else if (!pureOnly && isGatePassingMixedMonth(sortedEntries, entry)) {
+        } else if (!pureOnly && runtime.isGatePassingMixedMonth(entry)) {
             shouldInclude = true
             countedAsMixedMonth = true
         }
@@ -360,6 +417,25 @@ export function getRollingReferenceCoverage(
 }
 
 /**
+ * Computes rolling-reference coverage for a target entry.
+ * @param {HolidayEntry[]} sortedEntries
+ * @param {HolidayEntry} targetEntry
+ * @param {{ pureOnly?: boolean }} [options]
+ * @returns {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, mixedMonthsIncluded: number, scannedEntries: number }}
+ */
+export function getRollingReferenceCoverage(
+    sortedEntries,
+    targetEntry,
+    options = {}
+) {
+    return computeRollingReferenceCoverage(
+        createHolidayReferenceRuntimeFromSortedEntries(sortedEntries),
+        targetEntry,
+        options
+    )
+}
+
+/**
  * @param {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, mixedMonthsIncluded: number }} coverage
  * @returns {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, limitedData: boolean, mixedMonthsIncluded: number, confidence: ReferenceConfidence } | null}
  */
@@ -383,16 +459,12 @@ function buildRollingReferenceFromCoverage(coverage) {
 }
 
 /**
- * @param {HolidayEntry[]} sortedEntries
+ * @param {any} runtime
  * @param {HolidayEntry} targetEntry
  * @param {{ pureOnly?: boolean }} [options]
  * @returns {{ coverage: { totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, mixedMonthsIncluded: number, scannedEntries: number }, reference: { totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, limitedData: boolean, mixedMonthsIncluded: number, confidence: ReferenceConfidence } | null }}
  */
-function buildRollingReferenceWithCoverage(
-    sortedEntries,
-    targetEntry,
-    options = {}
-) {
+function buildRollingReferenceWithCoverage(runtime, targetEntry, options = {}) {
     const timingEnabled = Boolean(timing?.enabled)
     const startedAt = timingEnabled ? globalThis.performance.now() : 0
     const pureOnly = Boolean(options.pureOnly)
@@ -419,7 +491,7 @@ function buildRollingReferenceWithCoverage(
         }
     }
 
-    const coverage = getRollingReferenceCoverage(sortedEntries, targetEntry, {
+    const coverage = computeRollingReferenceCoverage(runtime, targetEntry, {
         pureOnly,
     })
 
@@ -465,12 +537,51 @@ function buildRollingReferenceWithCoverage(
 }
 
 /**
- * @param {HolidayEntry[]} sortedEntries
+ * @param {any} runtime
  * @param {HolidayEntry} targetEntry
- * @returns {{ totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, limitedData: boolean, mixedMonthsIncluded: number, confidence: ReferenceConfidence } | null}
+ * @param {boolean} pureOnly
+ * @returns {{ coverage: { totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, mixedMonthsIncluded: number, scannedEntries: number }, reference: { totalBasicPay: number, totalBasicHours: number, totalWeeks: number, periodsCounted: number, limitedData: boolean, mixedMonthsIncluded: number, confidence: ReferenceConfidence } | null }}
  */
-function buildPureRollingReference(sortedEntries, targetEntry) {
-    return buildRollingReference(sortedEntries, targetEntry, { pureOnly: true })
+function getCachedRollingReferenceWithCoverage(runtime, targetEntry, pureOnly) {
+    const cache = pureOnly ? runtime.pureReferenceCache : runtime.referenceCache
+    if (cache.has(targetEntry)) {
+        return cache.get(targetEntry)
+    }
+    const result = buildRollingReferenceWithCoverage(runtime, targetEntry, {
+        pureOnly,
+    })
+    cache.set(targetEntry, result)
+    return result
+}
+
+/**
+ * @param {any} runtime
+ * @param {HolidayEntry} mixedEntry
+ * @returns {boolean}
+ */
+function getCachedGateDecision(runtime, mixedEntry) {
+    if (runtime.gateCache.has(mixedEntry)) {
+        return Boolean(runtime.gateCache.get(mixedEntry))
+    }
+    let allowed = false
+    if (isMixedMonthCandidate(mixedEntry) && mixedEntry.parsedDate) {
+        const pureRef = runtime.getPureReferenceData(mixedEntry).reference
+        if (
+            pureRef &&
+            pureRef.totalWeeks >= 12 &&
+            pureRef.totalBasicHours > 0
+        ) {
+            const expectedHours =
+                (pureRef.totalBasicHours / pureRef.totalWeeks) *
+                getWeeksInPeriod(mixedEntry.parsedDate)
+            if (expectedHours > 0) {
+                const actualHours = getBasicPay(mixedEntry)?.units ?? 0
+                allowed = actualHours / expectedHours >= 0.75
+            }
+        }
+    }
+    runtime.gateCache.set(mixedEntry, allowed)
+    return allowed
 }
 
 /**
@@ -479,21 +590,9 @@ function buildPureRollingReference(sortedEntries, targetEntry) {
  * @returns {boolean}
  */
 export function isGatePassingMixedMonth(sortedEntries, mixedEntry) {
-    if (!isMixedMonthCandidate(mixedEntry) || !mixedEntry.parsedDate) {
-        return false
-    }
-    const pureRef = buildPureRollingReference(sortedEntries, mixedEntry)
-    if (!pureRef || pureRef.totalWeeks < 12 || pureRef.totalBasicHours <= 0) {
-        return false
-    }
-    const expectedHours =
-        (pureRef.totalBasicHours / pureRef.totalWeeks) *
-        getWeeksInPeriod(mixedEntry.parsedDate)
-    if (expectedHours <= 0) {
-        return false
-    }
-    const actualHours = getBasicPay(mixedEntry)?.units ?? 0
-    return actualHours / expectedHours >= 0.75
+    return createHolidayReferenceRuntimeFromSortedEntries(
+        sortedEntries
+    ).isGatePassingMixedMonth(mixedEntry)
 }
 
 /**
@@ -542,11 +641,11 @@ export function buildRollingReference(
     targetEntry,
     options = {}
 ) {
-    return buildRollingReferenceWithCoverage(
-        sortedEntries,
-        targetEntry,
-        options
-    ).reference
+    const runtime =
+        createHolidayReferenceRuntimeFromSortedEntries(sortedEntries)
+    return options.pureOnly
+        ? runtime.getPureReferenceData(targetEntry).reference
+        : runtime.getReferenceData(targetEntry).reference
 }
 
 /**
@@ -563,19 +662,16 @@ export function buildRollingReference(
  * to avoid overlapping warnings with the same root cause.
  *
  * @param {HolidayEntry[]} entries
+ * @param {any} [runtime=null]
  * @returns {void}
  */
-export function buildHolidayPayFlags(entries) {
+export function buildHolidayPayFlags(entries, runtime = null) {
     if (timing?.enabled) {
         timing.start('holidayFlags.total')
         timing.increment('holidayFlags.calls')
         timing.increment('holidayFlags.entriesSeen', entries.length)
     }
-    const sortedEntries = [...entries].sort((a, b) => {
-        const aTime = a.parsedDate?.getTime() ?? 0
-        const bTime = b.parsedDate?.getTime() ?? 0
-        return aTime - bTime
-    })
+    const resolvedRuntime = runtime || createHolidayReferenceRuntime(entries)
 
     for (const entry of entries) {
         const hourly = entry.record?.payrollDoc?.payments?.hourly
@@ -612,10 +708,8 @@ export function buildHolidayPayFlags(entries) {
                   ? basicAmount / basicUnits
                   : null
 
-        const { coverage, reference: ref } = buildRollingReferenceWithCoverage(
-            sortedEntries,
-            entry
-        )
+        const { coverage, reference: ref } =
+            resolvedRuntime.getReferenceData(entry)
         applyMixedMonthLowConfidence(entry, ref)
 
         if (!ref && coverage.periodsCounted < 3) {
@@ -721,9 +815,14 @@ export function buildHolidayPayFlags(entries) {
  *
  * @param {HolidayEntry[]} entries
  * @param {{ workerType?: string, typicalDays?: number, statutoryHolidayDays?: number | null, leaveYearStartMonth?: number } | null} workerProfile
+ * @param {any} [runtime=null]
  * @returns {void}
  */
-export function buildYearHolidayContext(entries, workerProfile) {
+export function buildYearHolidayContext(
+    entries,
+    workerProfile,
+    runtime = null
+) {
     if (timing?.enabled) {
         timing.start('holidayContext.total')
         timing.increment('holidayContext.calls')
@@ -734,18 +833,13 @@ export function buildYearHolidayContext(entries, workerProfile) {
             ? workerProfile.typicalDays
             : 0
     const leaveYearStartMonth = workerProfile?.leaveYearStartMonth ?? 4
-
-    const sortedEntries = [...entries].sort((a, b) => {
-        const aTime = a.parsedDate?.getTime() ?? 0
-        const bTime = b.parsedDate?.getTime() ?? 0
-        return aTime - bTime
-    })
+    const resolvedRuntime = runtime || createHolidayReferenceRuntime(entries)
 
     for (const entry of entries) {
         if (timing?.enabled) {
             timing.increment('holidayContext.rollingReferenceCalls')
         }
-        const ref = buildRollingReference(sortedEntries, entry)
+        const ref = resolvedRuntime.getReferenceData(entry).reference
         applyMixedMonthLowConfidence(entry, ref)
 
         /** @type {any} */

--- a/pwa/src/report/html_export.js
+++ b/pwa/src/report/html_export.js
@@ -331,7 +331,7 @@ export function renderHtmlReport(context, meta) {
 
     reportSections.push('<div class="page">')
     reportSections.push(
-        `<div class="${summaryViewModel.globalCoverageNotice || summaryViewModel.contractTypeMismatchWarning ? 'has-notice report-meta' : 'report-meta'}">` +
+        `<div class="${summaryViewModel.globalCoverageNotice || summaryViewModel.contractTypeMismatchWarning || summaryViewModel.thresholdStalenessNotice ? 'has-notice report-meta' : 'report-meta'}">` +
             `<h2>Payroll Report — ${summaryViewModel.heading.employeeName}</h2>` +
             `<p class="report-range">${summaryViewModel.heading.dateRangeLabel}</p>` +
             `<p class="report-meta-generated"><b>Generated:</b> ${summaryViewModel.heading.generatedLabel || 'Unknown'}</p>` +
@@ -347,13 +347,18 @@ export function renderHtmlReport(context, meta) {
             `<div class="notice error"><span class="warning-icon">⚠︎</span> ${summaryViewModel.contractTypeMismatchWarning}</div>`
         )
     }
+    if (summaryViewModel.thresholdStalenessNotice) {
+        reportSections.push(
+            `<div class="notice error"><span class="warning-icon">⚠︎</span> ${summaryViewModel.thresholdStalenessNotice.message}</div>`
+        )
+    }
     if (summaryViewModel.globalCoverageNotice) {
         reportSections.push(
             `<div class="notice"><p >${summaryViewModel.globalCoverageNotice.message}</p></div>`
         )
     }
     reportSections.push(
-        `<h2 class="${summaryViewModel.globalCoverageNotice || summaryViewModel.contractTypeMismatchWarning ? 'has-notice' : ''}">${YEAR_SUMMARY_TITLE}: (${summaryViewModel.heading.dateRangeLabel})</h2>`
+        `<h2 class="${summaryViewModel.globalCoverageNotice || summaryViewModel.contractTypeMismatchWarning || summaryViewModel.thresholdStalenessNotice ? 'has-notice' : ''}">${YEAR_SUMMARY_TITLE}: (${summaryViewModel.heading.dateRangeLabel})</h2>`
     )
 
     if (summaryYearRowsHtml) {

--- a/pwa/src/report/html_export.js
+++ b/pwa/src/report/html_export.js
@@ -409,7 +409,7 @@ export function renderHtmlReport(context, meta) {
     const yearCoveragePrecomputed = prepareCoverageEntries(
         /** @type {any[]} */ (context.entries || [])
     )
-    const yearEntryIndexPrecomputed = new Map(
+    const globalEntryIndexPrecomputed = new Map(
         /** @type {any[]} */ (context.entries || []).map((entry, index) => [
             entry,
             index,
@@ -444,7 +444,7 @@ export function renderHtmlReport(context, meta) {
             },
             openingBalance,
             yearCoveragePrecomputed,
-            yearEntryIndexPrecomputed
+            globalEntryIndexPrecomputed
         )
         reportSections.push('<div class="page">')
         reportSections.push(

--- a/pwa/src/report/html_export.js
+++ b/pwa/src/report/html_export.js
@@ -7,6 +7,7 @@ import {
     buildHolidaySummaryDisplay,
     buildMiscReviewLine,
     buildSummaryNoticesList,
+    buildYearNoticesList,
     buildWorkerProfileSummaryFields,
     buildYearRowHolidayDisplay,
     formatContribution,
@@ -450,26 +451,20 @@ export function renderHtmlReport(context, meta) {
         reportSections.push(
             `<h2 id="${yearViewModel.heading.anchorId}">${yearViewModel.heading.yearKey} Summary: ${employeeName}</h2>`
         )
-        const yearNoticeItemsHtml = []
-        if (yearViewModel.coverageWarning?.message) {
-            yearNoticeItemsHtml.push(
-                `<li>${yearViewModel.coverageWarning.message}</li>`
-            )
-        }
-        if (yearViewModel.missingMonths.length) {
-            yearNoticeItemsHtml.push(
-                `<li>Missing months: <span class="missing-months">${yearViewModel.missingMonths.join(', ')}</span></li>`
-            )
-        }
-        if (yearNoticeItemsHtml.length > 0) {
-            const noticeListHtml = yearNoticeItemsHtml.join('')
-            reportSections.push(
-                `<div class="notice">` +
-                    (yearNoticeItemsHtml.length === 1
-                        ? `<p>${yearNoticeItemsHtml[0].replace(/^<li>|<\/li>$/g, '')}</p>`
-                        : `<ul>${noticeListHtml}</ul>`) +
-                    `</div>`
-            )
+        const yearNotices = buildYearNoticesList(yearViewModel)
+        if (yearNotices.length > 0) {
+            const renderedYearNotices = yearNotices.map((notice) => {
+                if (notice.startsWith('Missing months: ')) {
+                    const months = notice.slice('Missing months: '.length)
+                    return `Missing months: <span class="missing-months">${months}</span>`
+                }
+                return notice
+            })
+            const noticeHtml =
+                renderedYearNotices.length === 1
+                    ? `<p>${renderedYearNotices[0]}</p>`
+                    : `<ul>${renderedYearNotices.map((notice) => `<li>${notice}</li>`).join('')}</ul>`
+            reportSections.push(`<div class="notice">${noticeHtml}</div>`)
         }
 
         reportSections.push(renderYearSummaryFromViewModel(yearViewModel))

--- a/pwa/src/report/html_export.js
+++ b/pwa/src/report/html_export.js
@@ -409,6 +409,12 @@ export function renderHtmlReport(context, meta) {
     const yearCoveragePrecomputed = prepareCoverageEntries(
         /** @type {any[]} */ (context.entries || [])
     )
+    const yearEntryIndexPrecomputed = new Map(
+        /** @type {any[]} */ (context.entries || []).map((entry, index) => [
+            entry,
+            index,
+        ])
+    )
     Array.from(context.yearGroups.keys()).forEach((yearKey) => {
         const entriesForYear = context.yearGroups.get(yearKey)
         if (!entriesForYear) {
@@ -437,7 +443,8 @@ export function renderHtmlReport(context, meta) {
                 workerProfile: context.workerProfile,
             },
             openingBalance,
-            yearCoveragePrecomputed
+            yearCoveragePrecomputed,
+            yearEntryIndexPrecomputed
         )
         reportSections.push('<div class="page">')
         reportSections.push(

--- a/pwa/src/report/html_export.js
+++ b/pwa/src/report/html_export.js
@@ -21,6 +21,7 @@ import {
     buildPayslipViewModel,
     buildSummaryViewModel,
     buildYearViewModel,
+    prepareCoverageEntries,
 } from './report_view_model.js'
 
 const HOURLY_ACCRUAL_FACTOR = 0.1207
@@ -405,6 +406,9 @@ export function renderHtmlReport(context, meta) {
     reportSections.push(summaryNotesHtml)
     reportSections.push('</div>')
 
+    const yearCoveragePrecomputed = prepareCoverageEntries(
+        /** @type {any[]} */ (context.entries || [])
+    )
     Array.from(context.yearGroups.keys()).forEach((yearKey) => {
         const entriesForYear = context.yearGroups.get(yearKey)
         if (!entriesForYear) {
@@ -432,7 +436,8 @@ export function renderHtmlReport(context, meta) {
                 },
                 workerProfile: context.workerProfile,
             },
-            openingBalance
+            openingBalance,
+            yearCoveragePrecomputed
         )
         reportSections.push('<div class="page">')
         reportSections.push(

--- a/pwa/src/report/html_export.js
+++ b/pwa/src/report/html_export.js
@@ -6,6 +6,7 @@ import {
     buildDiffDisplay,
     buildHolidaySummaryDisplay,
     buildMiscReviewLine,
+    buildSummaryNoticesList,
     buildWorkerProfileSummaryFields,
     buildYearRowHolidayDisplay,
     formatContribution,
@@ -342,19 +343,24 @@ export function renderHtmlReport(context, meta) {
             `</div>` +
             `</div>`
     )
-    if (summaryViewModel.contractTypeMismatchWarning) {
+    const summaryNotices = buildSummaryNoticesList(summaryViewModel)
+    if (summaryNotices.length > 0) {
+        const noticeListHtml = summaryNotices
+            .map((notice) => `<li>${notice}</li>`)
+            .join('')
+        let noticeClass = 'notice'
+        if (
+            summaryViewModel.contractTypeMismatchWarning ||
+            summaryViewModel.thresholdStalenessNotice
+        ) {
+            noticeClass = 'notice error'
+        }
         reportSections.push(
-            `<div class="notice error"><span class="warning-icon">⚠︎</span> ${summaryViewModel.contractTypeMismatchWarning}</div>`
-        )
-    }
-    if (summaryViewModel.thresholdStalenessNotice) {
-        reportSections.push(
-            `<div class="notice error"><span class="warning-icon">⚠︎</span> ${summaryViewModel.thresholdStalenessNotice.message}</div>`
-        )
-    }
-    if (summaryViewModel.globalCoverageNotice) {
-        reportSections.push(
-            `<div class="notice"><p >${summaryViewModel.globalCoverageNotice.message}</p></div>`
+            `<div class="${noticeClass}">` +
+                (summaryNotices.length === 1
+                    ? `<span class="warning-icon">⚠︎</span> ${summaryNotices[0]}`
+                    : `<ul>${noticeListHtml}</ul>`) +
+                `</div>`
         )
     }
     reportSections.push(
@@ -432,17 +438,28 @@ export function renderHtmlReport(context, meta) {
         reportSections.push(
             `<h2 id="${yearViewModel.heading.anchorId}">${yearViewModel.heading.yearKey} Summary: ${employeeName}</h2>`
         )
-        if (yearViewModel.coverageWarning) {
-            reportSections.push(
-                `<div class="notice "><p>${yearViewModel.coverageWarning.message}</p></div>`
+        const yearNoticeItemsHtml = []
+        if (yearViewModel.coverageWarning?.message) {
+            yearNoticeItemsHtml.push(
+                `<li>${yearViewModel.coverageWarning.message}</li>`
             )
         }
         if (yearViewModel.missingMonths.length) {
-            const yearMissingPill = `<div class="notice"><p>Missing months: <span class="missing-months">${yearViewModel.missingMonths.join(', ')}</span></p></div>`
-            reportSections.push(
-                `<div class="report-missing">${yearMissingPill}</div>`
+            yearNoticeItemsHtml.push(
+                `<li>Missing months: <span class="missing-months">${yearViewModel.missingMonths.join(', ')}</span></li>`
             )
         }
+        if (yearNoticeItemsHtml.length > 0) {
+            const noticeListHtml = yearNoticeItemsHtml.join('')
+            reportSections.push(
+                `<div class="notice">` +
+                    (yearNoticeItemsHtml.length === 1
+                        ? `<p>${yearNoticeItemsHtml[0].replace(/^<li>|<\/li>$/g, '')}</p>`
+                        : `<ul>${noticeListHtml}</ul>`) +
+                    `</div>`
+            )
+        }
+
         reportSections.push(renderYearSummaryFromViewModel(yearViewModel))
         if (yearViewModel.flagNotes.length) {
             const noteItems = yearViewModel.flagNotes

--- a/pwa/src/report/pay_calculations_hourly.js
+++ b/pwa/src/report/pay_calculations_hourly.js
@@ -620,10 +620,11 @@ export function buildValidation(entry) {
     const flags = /** @type {ValidationFlag[]} */ ([])
     const natInsNumber = record.employee?.natInsNumber || ''
     const taxCode = record.payrollDoc?.taxCode?.code || ''
-    // The `|| 0` coercions below mean both payeTax and nationalInsurance are
-    // always >= 0 at the point the validators see them. Real-world refunds
-    // appear in payments.misc (not as negative deductions), so the validators
-    // below treat <= 0 as "zero or missing" — not "possible refund".
+    // Parsing invariants keep deduction amounts non-negative before they reach
+    // these validators. The `|| 0` coercions below are only fallbacks for
+    // missing/falsy values, not a non-negativity guarantee. Real-world refunds
+    // are expected via payments.misc (not negative deductions), so validators
+    // treat <= 0 as "zero or missing" rather than "refund".
     const payeTax = record.payrollDoc?.deductions?.payeTax?.amount || 0
     const nationalInsurance = record.payrollDoc?.deductions?.natIns?.amount || 0
     const totalGrossPay =

--- a/pwa/src/report/pay_calculations_hourly.js
+++ b/pwa/src/report/pay_calculations_hourly.js
@@ -620,6 +620,10 @@ export function buildValidation(entry) {
     const flags = /** @type {ValidationFlag[]} */ ([])
     const natInsNumber = record.employee?.natInsNumber || ''
     const taxCode = record.payrollDoc?.taxCode?.code || ''
+    // The `|| 0` coercions below mean both payeTax and nationalInsurance are
+    // always >= 0 at the point the validators see them. Real-world refunds
+    // appear in payments.misc (not as negative deductions), so the validators
+    // below treat <= 0 as "zero or missing" — not "possible refund".
     const payeTax = record.payrollDoc?.deductions?.payeTax?.amount || 0
     const nationalInsurance = record.payrollDoc?.deductions?.natIns?.amount || 0
     const totalGrossPay =

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -56,7 +56,8 @@ const FONT_SMALL = 9
 // ─── Holiday accrual constants ────────────────────────────────────────────────
 
 const HOURLY_ACCRUAL_FACTOR = 0.1207
-const HOURLY_ACCRUAL_FALLBACK_LABEL = 'worked-hours fallback estimate (no baseline)'
+const HOURLY_ACCRUAL_FALLBACK_LABEL =
+    'worked-hours fallback estimate (no baseline)'
 
 // ─── Utility ─────────────────────────────────────────────────────────────────
 
@@ -501,11 +502,12 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
     y = /** @type {any} */ (doc).lastAutoTable?.finalY ?? y
     y += LINE_GAP * 2
 
-    if (summaryViewModel.contractTypeMismatchWarning) {
+    /**
+     * @param {string} warningBody
+     */
+    const renderSummaryWarningBox = (warningBody) => {
         y += SECTION_GAP
-        const warningText =
-            'WARNING: ' +
-            sanitizeText(summaryViewModel.contractTypeMismatchWarning)
+        const warningText = 'WARNING: ' + sanitizeText(warningBody)
         const WARN_ACCENT_W = 4
         const WARN_PAD_H = 10
         const WARN_PAD_V = 6
@@ -528,6 +530,16 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
         doc.text(warnLines, warnTextX, y + WARN_PAD_V + FONT_SMALL)
         doc.setTextColor(0, 0, 0)
         y += warnBoxH + SECTION_GAP
+    }
+
+    if (summaryViewModel.contractTypeMismatchWarning) {
+        renderSummaryWarningBox(summaryViewModel.contractTypeMismatchWarning)
+    }
+
+    if (summaryViewModel.thresholdStalenessNotice?.message) {
+        renderSummaryWarningBox(
+            summaryViewModel.thresholdStalenessNotice.message
+        )
     }
 
     if (summaryViewModel.globalCoverageNotice) {

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -1242,7 +1242,7 @@ export async function exportReportPdf(context, meta) {
     const yearCoveragePrecomputed = prepareCoverageEntries(
         /** @type {any[]} */ (context.entries || [])
     )
-    const yearEntryIndexPrecomputed = new Map(
+    const globalEntryIndexPrecomputed = new Map(
         /** @type {any[]} */ (context.entries || []).map((entry, index) => [
             entry,
             index,
@@ -1267,7 +1267,7 @@ export async function exportReportPdf(context, meta) {
             { yearPageNumbers, payslipPageNumbers },
             openingBalance,
             yearCoveragePrecomputed,
-            yearEntryIndexPrecomputed
+            globalEntryIndexPrecomputed
         )
         yearPageNumbers.set(strYearKey, pageNumber)
     })

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -24,6 +24,7 @@ import {
     buildPayslipViewModel,
     buildSummaryViewModel,
     buildYearViewModel,
+    prepareCoverageEntries,
 } from './report_view_model.js'
 import { CONTRIBUTION_RECENCY_DAYS_THRESHOLD } from './uk_thresholds.js'
 
@@ -756,6 +757,7 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
  * @param {any} context
  * @param {{ yearPageNumbers: Map<string, number>, payslipPageNumbers: Map<number, number> }} pageNumbers
  * @param {number} openingBalance
+ * @param {{ sortedEntries: import('./report_view_model.js').HolidayCoverageEntry[], normalizedEntryByOriginalEntry: Map<import('./report_view_model.js').ReportEntry, import('./report_view_model.js').HolidayCoverageEntry> } | null} [coverageEntriesPrecomputed]
  * @returns {number}
  */
 function renderYearPage(
@@ -764,7 +766,8 @@ function renderYearPage(
     yearKey,
     context,
     pageNumbers,
-    openingBalance
+    openingBalance,
+    coverageEntriesPrecomputed = null
 ) {
     doc.addPage()
     const pageNumber = doc.getCurrentPageInfo().pageNumber
@@ -773,7 +776,8 @@ function renderYearPage(
         entriesForYear,
         String(yearKey),
         context,
-        openingBalance
+        openingBalance,
+        coverageEntriesPrecomputed
     )
 
     y = writeHeading(
@@ -1246,6 +1250,9 @@ export async function exportReportPdf(context, meta) {
 
     context.employeeName = meta.employeeName || 'Unknown'
 
+    const yearCoveragePrecomputed = prepareCoverageEntries(
+        /** @type {any[]} */ (context.entries || [])
+    )
     context.yearGroups.forEach((entriesForYear, yearKey) => {
         const strYearKey = String(yearKey || 'Unknown')
         const yearIdx = pdfYearKeys.indexOf(strYearKey)
@@ -1263,7 +1270,8 @@ export async function exportReportPdf(context, meta) {
             strYearKey,
             context,
             { yearPageNumbers, payslipPageNumbers },
-            openingBalance
+            openingBalance,
+            yearCoveragePrecomputed
         )
         yearPageNumbers.set(strYearKey, pageNumber)
     })

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -550,7 +550,7 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
         } else {
             y += SECTION_GAP
             const bulletPoints = summaryNotices
-                .map((notice) => '• ' + sanitizeText(notice))
+                .map((notice) => '- ' + sanitizeText(notice))
                 .join('\n')
             const noticeBoxX = PAGE_MARGIN
             const noticeBoxW = maxWidth(doc)
@@ -794,7 +794,7 @@ function renderYearPage(
     } else if (yearNotices.length > 1) {
         y += SECTION_GAP
         const bulletPoints = yearNotices
-            .map((notice) => '• ' + sanitizeText(notice))
+            .map((notice) => '- ' + sanitizeText(notice))
             .join('\n')
         const noticeBoxX = PAGE_MARGIN
         const noticeBoxW = maxWidth(doc)

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -8,7 +8,9 @@ import {
     buildDiffDisplay,
     buildHolidaySummaryDisplay,
     buildMiscReviewLine,
+    buildSummaryNoticesList,
     buildWorkerProfileSummaryFields,
+    buildYearNoticesList,
     buildYearRowHolidayDisplay,
     FLAG_NOTES_TITLE,
     formatContribution,
@@ -532,20 +534,51 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
         y += warnBoxH + SECTION_GAP
     }
 
-    if (summaryViewModel.contractTypeMismatchWarning) {
-        renderSummaryWarningBox(summaryViewModel.contractTypeMismatchWarning)
-    }
+    const summaryNotices = buildSummaryNoticesList(summaryViewModel)
+    const hasErrors =
+        Boolean(summaryViewModel.contractTypeMismatchWarning) ||
+        Boolean(summaryViewModel.thresholdStalenessNotice)
 
-    if (summaryViewModel.thresholdStalenessNotice?.message) {
-        renderSummaryWarningBox(
-            summaryViewModel.thresholdStalenessNotice.message
-        )
-    }
-
-    if (summaryViewModel.globalCoverageNotice) {
-        y = writeText(doc, summaryViewModel.globalCoverageNotice.message, y, {
-            fontSize: FONT_SMALL,
-        })
+    if (summaryNotices.length > 0) {
+        if (summaryNotices.length === 1 && hasErrors) {
+            renderSummaryWarningBox(summaryNotices[0])
+        } else if (summaryNotices.length === 1) {
+            y = writeText(doc, summaryNotices[0], y, {
+                fontSize: FONT_SMALL,
+            })
+        } else {
+            y += SECTION_GAP
+            const bulletPoints = summaryNotices
+                .map((notice) => '• ' + sanitizeText(notice))
+                .join('\n')
+            const noticeBoxX = PAGE_MARGIN
+            const noticeBoxW = maxWidth(doc)
+            const NOTICE_PAD_H = 10
+            const NOTICE_PAD_V = 6
+            doc.setFont('helvetica', 'normal')
+            doc.setFontSize(FONT_SMALL)
+            const noticeLines = doc.splitTextToSize(
+                bulletPoints,
+                noticeBoxW - NOTICE_PAD_H * 2
+            )
+            const noticeLineH = FONT_SMALL * 1.3
+            const noticeTextH = noticeLines.length * noticeLineH
+            const noticeBoxH = noticeTextH + NOTICE_PAD_V * 2
+            y = ensureSpace(doc, y, noticeBoxH + SECTION_GAP)
+            doc.setFillColor(245, 245, 245)
+            doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH, 'F')
+            doc.setFillColor(100, 100, 100)
+            doc.setLineWidth(0.5)
+            doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH)
+            doc.setTextColor(50, 50, 50)
+            doc.text(
+                noticeLines,
+                noticeBoxX + NOTICE_PAD_H,
+                y + NOTICE_PAD_V + FONT_SMALL
+            )
+            doc.setTextColor(0, 0, 0)
+            y += noticeBoxH + SECTION_GAP
+        }
     }
 
     y = writeHeading(doc, YEAR_SUMMARY_TITLE, y, {
@@ -765,6 +798,41 @@ function renderYearPage(
         y = writeText(doc, yearViewModel.coverageWarning.message, y, {
             fontSize: FONT_SMALL,
         })
+    }
+
+    const yearNotices = buildYearNoticesList(yearViewModel)
+    if (yearNotices.length > 1) {
+        y += SECTION_GAP
+        const bulletPoints = yearNotices
+            .map((notice) => '• ' + sanitizeText(notice))
+            .join('\n')
+        const noticeBoxX = PAGE_MARGIN
+        const noticeBoxW = maxWidth(doc)
+        const NOTICE_PAD_H = 10
+        const NOTICE_PAD_V = 6
+        doc.setFont('helvetica', 'normal')
+        doc.setFontSize(FONT_SMALL)
+        const noticeLines = doc.splitTextToSize(
+            bulletPoints,
+            noticeBoxW - NOTICE_PAD_H * 2
+        )
+        const noticeLineH = FONT_SMALL * 1.3
+        const noticeTextH = noticeLines.length * noticeLineH
+        const noticeBoxH = noticeTextH + NOTICE_PAD_V * 2
+        y = ensureSpace(doc, y, noticeBoxH + SECTION_GAP)
+        doc.setFillColor(245, 245, 245)
+        doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH, 'F')
+        doc.setFillColor(100, 100, 100)
+        doc.setLineWidth(0.5)
+        doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH)
+        doc.setTextColor(50, 50, 50)
+        doc.text(
+            noticeLines,
+            noticeBoxX + NOTICE_PAD_H,
+            y + NOTICE_PAD_V + FONT_SMALL
+        )
+        doc.setTextColor(0, 0, 0)
+        y += noticeBoxH + SECTION_GAP
     }
 
     /** @type {Array<Array<string>>} */

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -788,24 +788,10 @@ function renderYearPage(
             preGap: 0,
         }
     )
-    if (yearViewModel.missingMonths.length) {
-        y = writeText(
-            doc,
-            `Missing months: ${yearViewModel.missingMonths.join(', ')}`,
-            y,
-            {
-                fontSize: FONT_SMALL,
-            }
-        )
-    }
-    if (yearViewModel.coverageWarning) {
-        y = writeText(doc, yearViewModel.coverageWarning.message, y, {
-            fontSize: FONT_SMALL,
-        })
-    }
-
     const yearNotices = buildYearNoticesList(yearViewModel)
-    if (yearNotices.length > 1) {
+    if (yearNotices.length === 1) {
+        y = writeText(doc, yearNotices[0], y, { fontSize: FONT_SMALL })
+    } else if (yearNotices.length > 1) {
         y += SECTION_GAP
         const bulletPoints = yearNotices
             .map((notice) => '• ' + sanitizeText(notice))

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -566,12 +566,28 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
             const noticeTextH = noticeLines.length * noticeLineH
             const noticeBoxH = noticeTextH + NOTICE_PAD_V * 2
             y = ensureSpace(doc, y, noticeBoxH + SECTION_GAP)
-            doc.setFillColor(245, 245, 245)
-            doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH, 'F')
-            doc.setFillColor(100, 100, 100)
-            doc.setLineWidth(0.5)
-            doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH)
-            doc.setTextColor(50, 50, 50)
+            if (hasErrors) {
+                doc.setFillColor(253, 244, 237)
+                doc.roundedRect(
+                    noticeBoxX,
+                    y,
+                    noticeBoxW,
+                    noticeBoxH,
+                    2,
+                    2,
+                    'F'
+                )
+                doc.setFillColor(194, 84, 45)
+                doc.rect(noticeBoxX, y, 4, noticeBoxH, 'F')
+                doc.setTextColor(74, 40, 0)
+            } else {
+                doc.setFillColor(245, 245, 245)
+                doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH, 'F')
+                doc.setFillColor(100, 100, 100)
+                doc.setLineWidth(0.5)
+                doc.rect(noticeBoxX, y, noticeBoxW, noticeBoxH)
+                doc.setTextColor(50, 50, 50)
+            }
             doc.text(
                 noticeLines,
                 noticeBoxX + NOTICE_PAD_H,

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -548,6 +548,10 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
                 fontSize: FONT_SMALL,
             })
         } else {
+            const isErrorNotice =
+                hasErrors ||
+                Boolean(summaryViewModel.thresholdStalenessNotice) ||
+                Boolean(summaryViewModel.contractTypeMismatchWarning)
             y += SECTION_GAP
             const bulletPoints = summaryNotices
                 .map((notice) => '- ' + sanitizeText(notice))
@@ -556,7 +560,7 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
             const noticeBoxW = maxWidth(doc)
             const NOTICE_PAD_H = 10
             const NOTICE_PAD_V = 6
-            doc.setFont('helvetica', 'normal')
+            doc.setFont('helvetica', isErrorNotice ? 'bold' : 'normal')
             doc.setFontSize(FONT_SMALL)
             const noticeLines = doc.splitTextToSize(
                 bulletPoints,
@@ -566,7 +570,7 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
             const noticeTextH = noticeLines.length * noticeLineH
             const noticeBoxH = noticeTextH + NOTICE_PAD_V * 2
             y = ensureSpace(doc, y, noticeBoxH + SECTION_GAP)
-            if (hasErrors) {
+            if (isErrorNotice) {
                 doc.setFillColor(253, 244, 237)
                 doc.roundedRect(
                     noticeBoxX,

--- a/pwa/src/report/pdf_export.js
+++ b/pwa/src/report/pdf_export.js
@@ -758,6 +758,7 @@ function renderSummaryPage(doc, context, meta, pageNumbers) {
  * @param {{ yearPageNumbers: Map<string, number>, payslipPageNumbers: Map<number, number> }} pageNumbers
  * @param {number} openingBalance
  * @param {{ sortedEntries: import('./report_view_model.js').HolidayCoverageEntry[], normalizedEntryByOriginalEntry: Map<import('./report_view_model.js').ReportEntry, import('./report_view_model.js').HolidayCoverageEntry> } | null} [coverageEntriesPrecomputed]
+ * @param {Map<import('./report_view_model.js').ReportEntry, number> | null} [globalEntryIndexByEntryPrecomputed]
  * @returns {number}
  */
 function renderYearPage(
@@ -767,7 +768,8 @@ function renderYearPage(
     context,
     pageNumbers,
     openingBalance,
-    coverageEntriesPrecomputed = null
+    coverageEntriesPrecomputed = null,
+    globalEntryIndexByEntryPrecomputed = null
 ) {
     doc.addPage()
     const pageNumber = doc.getCurrentPageInfo().pageNumber
@@ -777,7 +779,8 @@ function renderYearPage(
         String(yearKey),
         context,
         openingBalance,
-        coverageEntriesPrecomputed
+        coverageEntriesPrecomputed,
+        globalEntryIndexByEntryPrecomputed
     )
 
     y = writeHeading(
@@ -1239,6 +1242,12 @@ export async function exportReportPdf(context, meta) {
     const yearCoveragePrecomputed = prepareCoverageEntries(
         /** @type {any[]} */ (context.entries || [])
     )
+    const yearEntryIndexPrecomputed = new Map(
+        /** @type {any[]} */ (context.entries || []).map((entry, index) => [
+            entry,
+            index,
+        ])
+    )
     context.yearGroups.forEach((entriesForYear, yearKey) => {
         const strYearKey = String(yearKey || 'Unknown')
         const yearIdx = pdfYearKeys.indexOf(strYearKey)
@@ -1257,7 +1266,8 @@ export async function exportReportPdf(context, meta) {
             context,
             { yearPageNumbers, payslipPageNumbers },
             openingBalance,
-            yearCoveragePrecomputed
+            yearCoveragePrecomputed,
+            yearEntryIndexPrecomputed
         )
         yearPageNumbers.set(strYearKey, pageNumber)
     })

--- a/pwa/src/report/report_formatters.js
+++ b/pwa/src/report/report_formatters.js
@@ -111,6 +111,43 @@ export function buildThresholdStalenessNoticeMessage({
 }
 
 /**
+ * Consolidate global summary notices into a single array for efficient list rendering.
+ * @param {{ contractTypeMismatchWarning?: string | null, thresholdStalenessNotice?: { message: string } | null, globalCoverageNotice?: { message: string } | null }} summaryViewModel
+ * @returns {string[]}
+ */
+export function buildSummaryNoticesList(summaryViewModel) {
+    const notices = /** @type {string[]} */ ([])
+    if (summaryViewModel.contractTypeMismatchWarning) {
+        notices.push(summaryViewModel.contractTypeMismatchWarning)
+    }
+    if (summaryViewModel.thresholdStalenessNotice?.message) {
+        notices.push(summaryViewModel.thresholdStalenessNotice.message)
+    }
+    if (summaryViewModel.globalCoverageNotice?.message) {
+        notices.push(summaryViewModel.globalCoverageNotice.message)
+    }
+    return notices
+}
+
+/**
+ * Consolidate year summary notices into a single array for efficient list rendering.
+ * @param {{ coverageWarning?: { message: string } | null, missingMonths?: string[] }} yearViewModel
+ * @returns {string[]}
+ */
+export function buildYearNoticesList(yearViewModel) {
+    const notices = /** @type {string[]} */ ([])
+    if (yearViewModel.coverageWarning?.message) {
+        notices.push(yearViewModel.coverageWarning.message)
+    }
+    if (yearViewModel.missingMonths && yearViewModel.missingMonths.length > 0) {
+        notices.push(
+            `Missing months: ${yearViewModel.missingMonths.join(', ')}`
+        )
+    }
+    return notices
+}
+
+/**
  * @param {number} value
  * @returns {string}
  */

--- a/pwa/src/report/report_formatters.js
+++ b/pwa/src/report/report_formatters.js
@@ -92,6 +92,25 @@ export function buildGlobalCoverageNoticeMessage(affectedYears) {
 }
 
 /**
+ * @param {{ runTaxYearLabel: string | null, fallbackTaxYearLabels: string[], affectedPeriods: string[] }} params
+ * @returns {string}
+ */
+export function buildThresholdStalenessNoticeMessage({
+    runTaxYearLabel,
+    fallbackTaxYearLabels,
+    affectedPeriods,
+}) {
+    const runLabel = runTaxYearLabel || 'the current tax year'
+    const fallbackLabel = fallbackTaxYearLabels.length
+        ? fallbackTaxYearLabels.join(', ')
+        : 'the most recent available tax year'
+    const periodSuffix = affectedPeriods.length
+        ? ` Affected periods in this run: ${affectedPeriods.join(', ')}.`
+        : ''
+    return `Threshold data for ${runLabel} has not been updated. The report used thresholds from ${fallbackLabel}, so tax-related checks and warnings may be out of date for new-year payslips.${periodSuffix}`
+}
+
+/**
  * @param {number} value
  * @returns {string}
  */

--- a/pwa/src/report/report_view_model.js
+++ b/pwa/src/report/report_view_model.js
@@ -789,6 +789,9 @@ export function buildYearViewModel(
 ) {
     const yearEntries = /** @type {ReportEntry[]} */ (entriesForYear || [])
     const allEntries = /** @type {ReportEntry[]} */ (context.entries || [])
+    const globalEntryIndexByEntry = new Map(
+        allEntries.map((entry, index) => [entry, index])
+    )
     const monthEntries = new Map()
     yearEntries.forEach((entry) => {
         if (entry.monthIndex >= 1 && entry.monthIndex <= 12) {
@@ -903,7 +906,8 @@ export function buildYearViewModel(
                             ? `${monthLabelBase} (${entryIndex + 1})`
                             : monthLabelBase,
                     monthAnchorId,
-                    globalEntryIndex: allEntries.indexOf(entry),
+                    globalEntryIndex:
+                        globalEntryIndexByEntry.get(entry) ?? null,
                     hours,
                     holidaySummary,
                     salaryHolidayAmount,

--- a/pwa/src/report/report_view_model.js
+++ b/pwa/src/report/report_view_model.js
@@ -400,6 +400,23 @@ function collectMiscReviewItems(entries) {
     return result
 }
 
+/**
+ * @param {Array<{ type: string, dateLabel: string, yearKey?: string, item: PayrollPayItem | PayrollMiscDeduction }> | null | undefined} miscFootnotes
+ */
+function buildMiscReviewItemsFromFootnotes(miscFootnotes) {
+    if (!Array.isArray(miscFootnotes) || !miscFootnotes.length) {
+        return []
+    }
+    return miscFootnotes.map((footnote) => ({
+        type: footnote.type,
+        dateLabel: footnote.dateLabel,
+        label: formatMiscLabel(footnote.item),
+        amount: footnote.item?.amount || 0,
+        units: footnote.item?.units ?? null,
+        rate: footnote.item?.rate ?? null,
+    }))
+}
+
 /** @param {ReportEntry[]} entriesForYear */
 function buildYearFlagModel(entriesForYear) {
     const noteIndexByLabel = new Map()
@@ -559,6 +576,9 @@ export function buildSummaryViewModel(context, meta) {
     )
     const groupedFlaggedPeriods = groupPeriodsByYear(flaggedPeriods)
     const groupedLowConfidencePeriods = groupPeriodsByYear(lowConfidencePeriods)
+    const miscReviewItems = buildMiscReviewItemsFromFootnotes(
+        context.miscFootnotes
+    )
     const auditMetadata = context.auditMetadata || null
     const pdfCount = entries.length
     const metaRows = [
@@ -752,7 +772,9 @@ export function buildSummaryViewModel(context, meta) {
             contributionRecency: context.contributionRecency || null,
             hasContributionSummary: Boolean(context.contributionSummary?.years),
         },
-        miscReviewItems: collectMiscReviewItems(entries),
+        miscReviewItems: miscReviewItems.length
+            ? miscReviewItems
+            : collectMiscReviewItems(entries),
         notes,
     }
 }
@@ -1083,7 +1105,17 @@ export function buildYearViewModel(
             context.missingMonths?.missingMonthsByYear?.[yearKey] || [],
         rows,
         footerRows,
-        miscReviewItems: collectMiscReviewItems(yearEntries),
+        miscReviewItems: (() => {
+            const fromCtx = buildMiscReviewItemsFromFootnotes(
+                (context.miscFootnotes || []).filter(
+                    (/** @type {{ yearKey?: string | null }} */ fn) =>
+                        fn.yearKey === yearKey
+                )
+            )
+            return fromCtx.length
+                ? fromCtx
+                : collectMiscReviewItems(yearEntries)
+        })(),
         flagNotes: noteLabels,
         notes,
     }

--- a/pwa/src/report/report_view_model.js
+++ b/pwa/src/report/report_view_model.js
@@ -779,19 +779,20 @@ export function buildSummaryViewModel(context, meta) {
     }
 }
 
-/** @param {any} entriesForYear @param {string} yearKey @param {any} context @param {number} openingBalance @param {{ sortedEntries: HolidayCoverageEntry[], normalizedEntryByOriginalEntry: Map<ReportEntry, HolidayCoverageEntry> } | null} [coverageEntriesPrecomputed] */
+/** @param {any} entriesForYear @param {string} yearKey @param {any} context @param {number} openingBalance @param {{ sortedEntries: HolidayCoverageEntry[], normalizedEntryByOriginalEntry: Map<ReportEntry, HolidayCoverageEntry> } | null} [coverageEntriesPrecomputed] @param {Map<ReportEntry, number> | null} [globalEntryIndexByEntryPrecomputed] */
 export function buildYearViewModel(
     entriesForYear,
     yearKey,
     context,
     openingBalance,
-    coverageEntriesPrecomputed = null
+    coverageEntriesPrecomputed = null,
+    globalEntryIndexByEntryPrecomputed = null
 ) {
     const yearEntries = /** @type {ReportEntry[]} */ (entriesForYear || [])
     const allEntries = /** @type {ReportEntry[]} */ (context.entries || [])
-    const globalEntryIndexByEntry = new Map(
-        allEntries.map((entry, index) => [entry, index])
-    )
+    const globalEntryIndexByEntry =
+        globalEntryIndexByEntryPrecomputed ??
+        new Map(allEntries.map((entry, index) => [entry, index]))
     const monthEntries = new Map()
     yearEntries.forEach((entry) => {
         if (entry.monthIndex >= 1 && entry.monthIndex <= 12) {

--- a/pwa/src/report/report_view_model.js
+++ b/pwa/src/report/report_view_model.js
@@ -17,6 +17,7 @@ import {
     buildAnnualCrossCheckDisplay,
     buildCoverageWarningMessage,
     buildGlobalCoverageNoticeMessage,
+    buildThresholdStalenessNoticeMessage,
     buildZeroTaxAllowanceNote,
     APRIL_BOUNDARY_NOTE,
     formatMiscLabel,
@@ -647,6 +648,37 @@ export function buildSummaryViewModel(context, meta) {
               affectedYears: yearsWithCoverageWarnings,
           }
         : null
+
+    const thresholdStalenessContext = context.thresholdStaleness || null
+    const runDate = thresholdStalenessContext?.reportRunDateIso
+        ? new Date(thresholdStalenessContext.reportRunDateIso)
+        : null
+    const isValidRunDate =
+        runDate instanceof Date && !Number.isNaN(runDate.getTime())
+    const runMonth = isValidRunDate ? runDate.getMonth() : -1
+    const runDay = isValidRunDate ? runDate.getDate() : -1
+    const isAfterAprilSix =
+        isValidRunDate && (runMonth > 3 || (runMonth === 3 && runDay > 6))
+    const hasNewTaxYearFallback =
+        Boolean(thresholdStalenessContext?.hasRunTaxYearFallback) &&
+        (thresholdStalenessContext?.affectedPeriods?.length || 0) > 0
+    const thresholdStalenessNotice =
+        isAfterAprilSix && hasNewTaxYearFallback
+            ? {
+                  message: buildThresholdStalenessNoticeMessage({
+                      runTaxYearLabel:
+                          thresholdStalenessContext?.runTaxYearLabel || null,
+                      fallbackTaxYearLabels:
+                          thresholdStalenessContext?.fallbackTaxYearLabels ||
+                          [],
+                      affectedPeriods:
+                          thresholdStalenessContext?.affectedPeriods || [],
+                  }),
+                  affectedPeriods:
+                      thresholdStalenessContext?.affectedPeriods || [],
+              }
+            : null
+
     const notes = /** @type {Array<{ id: string, text: string }>} */ ([
         {
             id: 'accumulated-totals',
@@ -701,6 +733,7 @@ export function buildSummaryViewModel(context, meta) {
         contractTypeMismatchWarning:
             context.contractTypeMismatchWarning || null,
         globalCoverageNotice,
+        thresholdStalenessNotice,
         yearSummaryRows,
         accumulatedTotals: {
             dateRangeLabel: meta.dateRangeLabel || 'Unknown',

--- a/pwa/src/report/report_view_model.js
+++ b/pwa/src/report/report_view_model.js
@@ -675,8 +675,8 @@ export function buildSummaryViewModel(context, meta) {
         : null
     const isValidRunDate =
         runDate instanceof Date && !Number.isNaN(runDate.getTime())
-    const runMonth = isValidRunDate ? runDate.getMonth() : -1
-    const runDay = isValidRunDate ? runDate.getDate() : -1
+    const runMonth = isValidRunDate ? runDate.getUTCMonth() : -1
+    const runDay = isValidRunDate ? runDate.getUTCDate() : -1
     const isAfterAprilSix =
         isValidRunDate && (runMonth > 3 || (runMonth === 3 && runDay > 6))
     const hasNewTaxYearFallback =

--- a/pwa/src/report/report_view_model.js
+++ b/pwa/src/report/report_view_model.js
@@ -779,12 +779,13 @@ export function buildSummaryViewModel(context, meta) {
     }
 }
 
-/** @param {any} entriesForYear @param {string} yearKey @param {any} context @param {number} openingBalance */
+/** @param {any} entriesForYear @param {string} yearKey @param {any} context @param {number} openingBalance @param {{ sortedEntries: HolidayCoverageEntry[], normalizedEntryByOriginalEntry: Map<ReportEntry, HolidayCoverageEntry> } | null} [coverageEntriesPrecomputed] */
 export function buildYearViewModel(
     entriesForYear,
     yearKey,
     context,
-    openingBalance
+    openingBalance,
+    coverageEntriesPrecomputed = null
 ) {
     const yearEntries = /** @type {ReportEntry[]} */ (entriesForYear || [])
     const allEntries = /** @type {ReportEntry[]} */ (context.entries || [])
@@ -995,7 +996,7 @@ export function buildYearViewModel(
     const coverageWarning = buildCoverageWarning(
         allEntries,
         yearEntries,
-        prepareCoverageEntries(allEntries)
+        coverageEntriesPrecomputed ?? prepareCoverageEntries(allEntries)
     )
     const annualCrossCheck =
         yearHolidaySummary.kind === 'hourly_hours'
@@ -1155,7 +1156,7 @@ function normalizeHolidayCoverageEntries(entries) {
  * @param {ReportEntry[]} allEntries
  * @returns {{ sortedEntries: HolidayCoverageEntry[], normalizedEntryByOriginalEntry: Map<ReportEntry, HolidayCoverageEntry> }}
  */
-function prepareCoverageEntries(allEntries) {
+export function prepareCoverageEntries(allEntries) {
     // Normalize allEntries once so that the same object references appear in both
     // sortedEntries and normalizedHolidayTargets. getRollingReferenceCoverage uses
     // entry === targetEntry (object identity) to skip the target month; a second

--- a/pwa/src/report/uk_thresholds.js
+++ b/pwa/src/report/uk_thresholds.js
@@ -10,6 +10,10 @@ export const RULES_VERSION = '2026-04-04'
 /** Version marker for the current threshold set. */
 export const THRESHOLDS_VERSION = RULES_VERSION
 
+/** Threshold review checks switch from warning to failure from 1 April each year. */
+export const THRESHOLD_REVIEW_CUTOFF_MONTH_INDEX = 3
+export const THRESHOLD_REVIEW_CUTOFF_DAY = 1
+
 /**
  * Year-variant statutory thresholds keyed by UK tax-year start year.
  *
@@ -236,6 +240,129 @@ export const TAX_YEAR_THRESHOLDS = Object.freeze({
         },
     }),
 })
+
+/**
+ * @typedef {{
+ *   status: 'ok' | 'warning' | 'expired' | 'invalid-thresholds-version' | 'invalid-reference-date',
+ *   thresholdsVersion: string,
+ *   thresholdsVersionDate: Date | null,
+ *   referenceDate: Date | null,
+ *   cutoffDate: Date | null,
+ * }} ThresholdStalenessStatus
+ */
+
+/**
+ * @param {string | null | undefined} version
+ * @returns {Date | null}
+ */
+export function parseThresholdsVersionDate(version) {
+    const match = String(version || '')
+        .trim()
+        .match(/^(\d{4})-(\d{2})-(\d{2})$/)
+    if (!match) {
+        return null
+    }
+    const year = Number.parseInt(match[1], 10)
+    const month = Number.parseInt(match[2], 10)
+    const day = Number.parseInt(match[3], 10)
+    if (
+        !Number.isFinite(year) ||
+        !Number.isFinite(month) ||
+        !Number.isFinite(day)
+    ) {
+        return null
+    }
+    const parsed = new Date(year, month - 1, day)
+    if (
+        Number.isNaN(parsed.getTime()) ||
+        parsed.getFullYear() !== year ||
+        parsed.getMonth() !== month - 1 ||
+        parsed.getDate() !== day
+    ) {
+        return null
+    }
+    return parsed
+}
+
+/**
+ * @returns {number | null}
+ */
+export function getLatestConfiguredThresholdTaxYearStart() {
+    const configuredYears = Object.keys(TAX_YEAR_THRESHOLDS)
+        .map((value) => Number.parseInt(value, 10))
+        .filter((year) => Number.isFinite(year))
+    if (!configuredYears.length) {
+        return null
+    }
+    return Math.max(...configuredYears)
+}
+
+/**
+ * @param {Date | null | undefined} [referenceDate=new Date()]
+ * @param {string | null | undefined} [thresholdsVersion=THRESHOLDS_VERSION]
+ * @returns {ThresholdStalenessStatus}
+ */
+export function getThresholdStalenessStatus(
+    referenceDate = new Date(),
+    thresholdsVersion = THRESHOLDS_VERSION
+) {
+    const versionDate = parseThresholdsVersionDate(thresholdsVersion)
+    if (!versionDate) {
+        return {
+            status: 'invalid-thresholds-version',
+            thresholdsVersion: String(thresholdsVersion || ''),
+            thresholdsVersionDate: null,
+            referenceDate:
+                referenceDate instanceof Date &&
+                !Number.isNaN(referenceDate.getTime())
+                    ? referenceDate
+                    : null,
+            cutoffDate: null,
+        }
+    }
+    if (
+        !(referenceDate instanceof Date) ||
+        Number.isNaN(referenceDate.getTime())
+    ) {
+        return {
+            status: 'invalid-reference-date',
+            thresholdsVersion: String(thresholdsVersion || ''),
+            thresholdsVersionDate: versionDate,
+            referenceDate: null,
+            cutoffDate: null,
+        }
+    }
+    const cutoffDate = new Date(
+        referenceDate.getFullYear(),
+        THRESHOLD_REVIEW_CUTOFF_MONTH_INDEX,
+        THRESHOLD_REVIEW_CUTOFF_DAY
+    )
+    if (versionDate >= cutoffDate) {
+        return {
+            status: 'ok',
+            thresholdsVersion: String(thresholdsVersion || ''),
+            thresholdsVersionDate: versionDate,
+            referenceDate,
+            cutoffDate,
+        }
+    }
+    if (referenceDate < cutoffDate) {
+        return {
+            status: 'warning',
+            thresholdsVersion: String(thresholdsVersion || ''),
+            thresholdsVersionDate: versionDate,
+            referenceDate,
+            cutoffDate,
+        }
+    }
+    return {
+        status: 'expired',
+        thresholdsVersion: String(thresholdsVersion || ''),
+        thresholdsVersionDate: versionDate,
+        referenceDate,
+        cutoffDate,
+    }
+}
 
 /** Default staleness threshold for contribution recency displays.
  * https://www.moneyhelper.org.uk/en/pensions-and-retirement/pension-problems/complaining-about-delays-to-your-pension#When-must-my-employer-make-my-pension-contributions-by--

--- a/pwa/src/report/uk_thresholds.js
+++ b/pwa/src/report/uk_thresholds.js
@@ -337,7 +337,9 @@ export function getThresholdStalenessStatus(
         THRESHOLD_REVIEW_CUTOFF_MONTH_INDEX,
         THRESHOLD_REVIEW_CUTOFF_DAY
     )
-    if (versionDate >= cutoffDate) {
+    const referenceYear = referenceDate.getFullYear()
+    const versionYear = versionDate.getFullYear()
+    if (versionYear >= referenceYear) {
         return {
             status: 'ok',
             thresholdsVersion: String(thresholdsVersion || ''),

--- a/pwa/styles.css
+++ b/pwa/styles.css
@@ -1070,6 +1070,7 @@ details:last-child {
 .details-content {
     block-size: 0;
     overflow: hidden;
+    margin-block-start: var(--space-12);
     transition: block-size 0.2s ease;
 }
 

--- a/pwa/styles.css
+++ b/pwa/styles.css
@@ -1696,11 +1696,6 @@ label.field span {
     margin-block-start: var(--space-6);
 }
 
-/* .small {
-    font-size: var(--text-sm);
-    color: var(--muted);
-} */
-
 /* ── Scroll to top ───────────────────────────────────────────────────────────── */
 
 .scroll-top {
@@ -1775,6 +1770,10 @@ label.field span {
     place-content: center center;
     overflow-x: auto;
     min-inline-size: 1100px;
+}
+
+.page > .notice:first-of-type {
+    margin-block-end: var(--space-16);
 }
 
 .stats {

--- a/scripts/check-threshold-staleness.mjs
+++ b/scripts/check-threshold-staleness.mjs
@@ -31,7 +31,10 @@ const today = overrideDate || new Date()
 const status = getThresholdStalenessStatus(today, THRESHOLDS_VERSION)
 const latestConfiguredTaxYearStart = getLatestConfiguredThresholdTaxYearStart()
 const expectedTaxYearStart =
-    today.getMonth() < 3 ? today.getFullYear() - 1 : today.getFullYear()
+    today.getMonth() < 3 ||
+    (today.getMonth() === 3 && today.getDate() < 6)
+        ? today.getFullYear() - 1
+        : today.getFullYear()
 const latestConfiguredLabel =
     latestConfiguredTaxYearStart === null
         ? 'none configured'

--- a/scripts/check-threshold-staleness.mjs
+++ b/scripts/check-threshold-staleness.mjs
@@ -31,8 +31,7 @@ const today = overrideDate || new Date()
 const status = getThresholdStalenessStatus(today, THRESHOLDS_VERSION)
 const latestConfiguredTaxYearStart = getLatestConfiguredThresholdTaxYearStart()
 const expectedTaxYearStart =
-    today.getMonth() < 3 ||
-    (today.getMonth() === 3 && today.getDate() < 6)
+    today.getMonth() < 3 || (today.getMonth() === 3 && today.getDate() < 6)
         ? today.getFullYear() - 1
         : today.getFullYear()
 const latestConfiguredLabel =

--- a/scripts/check-threshold-staleness.mjs
+++ b/scripts/check-threshold-staleness.mjs
@@ -30,7 +30,8 @@ if (process.env.THRESHOLD_CHECK_TODAY && !overrideDate) {
 const today = overrideDate || new Date()
 const status = getThresholdStalenessStatus(today, THRESHOLDS_VERSION)
 const latestConfiguredTaxYearStart = getLatestConfiguredThresholdTaxYearStart()
-const expectedTaxYearStart = today.getFullYear()
+const expectedTaxYearStart =
+    today.getMonth() < 3 ? today.getFullYear() - 1 : today.getFullYear()
 const latestConfiguredLabel =
     latestConfiguredTaxYearStart === null
         ? 'none configured'

--- a/scripts/check-threshold-staleness.mjs
+++ b/scripts/check-threshold-staleness.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import {
+    THRESHOLDS_VERSION,
+    getLatestConfiguredThresholdTaxYearStart,
+    getThresholdStalenessStatus,
+    parseThresholdsVersionDate,
+} from '../pwa/src/report/uk_thresholds.js'
+
+/**
+ * @param {string | undefined} value
+ * @returns {Date | null}
+ */
+function parseOverrideDate(value) {
+    if (!value) {
+        return null
+    }
+    const parsed = parseThresholdsVersionDate(value)
+    return parsed
+}
+
+const overrideDate = parseOverrideDate(process.env.THRESHOLD_CHECK_TODAY)
+if (process.env.THRESHOLD_CHECK_TODAY && !overrideDate) {
+    console.error(
+        '[threshold-check] Invalid THRESHOLD_CHECK_TODAY. Use YYYY-MM-DD.'
+    )
+    process.exit(1)
+}
+
+const today = overrideDate || new Date()
+const status = getThresholdStalenessStatus(today, THRESHOLDS_VERSION)
+const latestConfiguredTaxYearStart = getLatestConfiguredThresholdTaxYearStart()
+const expectedTaxYearStart = today.getFullYear()
+const latestConfiguredLabel =
+    latestConfiguredTaxYearStart === null
+        ? 'none configured'
+        : `${latestConfiguredTaxYearStart}/${String((latestConfiguredTaxYearStart + 1) % 100).padStart(2, '0')}`
+const expectedLabel = `${expectedTaxYearStart}/${String((expectedTaxYearStart + 1) % 100).padStart(2, '0')}`
+
+/**
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatDateLabel(date) {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+}
+
+const versionDateLabel =
+    status.thresholdsVersionDate instanceof Date
+        ? formatDateLabel(status.thresholdsVersionDate)
+        : 'invalid'
+const cutoffLabel =
+    status.cutoffDate instanceof Date
+        ? formatDateLabel(status.cutoffDate)
+        : 'unknown'
+
+const summary = [
+    `[threshold-check] THRESHOLDS_VERSION=${THRESHOLDS_VERSION} (${versionDateLabel})`,
+    `[threshold-check] current date=${formatDateLabel(today)} cutoff=${cutoffLabel}`,
+    `[threshold-check] latest configured tax year=${latestConfiguredLabel} expected current cycle=${expectedLabel}`,
+].join('\n')
+
+if (status.status === 'invalid-thresholds-version') {
+    console.error(summary)
+    console.error(
+        '[threshold-check] ERROR: THRESHOLDS_VERSION must be a valid YYYY-MM-DD date.'
+    )
+    process.exit(1)
+}
+
+if (status.status === 'invalid-reference-date') {
+    console.error(summary)
+    console.error(
+        '[threshold-check] ERROR: Invalid reference date for staleness check.'
+    )
+    process.exit(1)
+}
+
+if (status.status === 'warning') {
+    console.warn(summary)
+    console.warn(
+        '[threshold-check] WARNING: Threshold review for this cycle is due before April 1. Update and review pwa/src/report/uk_thresholds.js before cutoff.'
+    )
+    process.exit(0)
+}
+
+if (status.status === 'expired') {
+    console.error(summary)
+    console.error(
+        '[threshold-check] ERROR: Threshold review is overdue for this cycle (past April 1). Update and review pwa/src/report/uk_thresholds.js before building.'
+    )
+    process.exit(1)
+}
+
+console.log(summary)
+console.log(
+    '[threshold-check] OK: Threshold review version is current for this cycle.'
+)

--- a/tests/hol_pay_flags.test.mjs
+++ b/tests/hol_pay_flags.test.mjs
@@ -2086,6 +2086,161 @@ describe('insufficient-history low-confidence holiday notices', () => {
     })
 })
 
+describe('two-pass holiday pipeline characterization', () => {
+    it('preserves mixed-month propagation consistently across flags and holidayContext', () => {
+        const entries = [
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 1,
+                parsedDate: new Date(2024, 0, 15),
+            }),
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 2,
+                parsedDate: new Date(2024, 1, 15),
+            }),
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 3,
+                parsedDate: new Date(2024, 2, 15),
+            }),
+            makeEntry({
+                basicUnits: 128,
+                basicRate: 12.5,
+                holidayUnits: 8,
+                holidayAmount: 72,
+                monthIndex: 4,
+                parsedDate: new Date(2024, 3, 15),
+            }),
+        ]
+        const target = makeEntry({
+            basicUnits: 0,
+            basicRate: null,
+            basicAmount: 0,
+            holidayUnits: 8,
+            holidayAmount: 72,
+            monthIndex: 5,
+            parsedDate: new Date(2024, 4, 15),
+        })
+        const reportEntries = [...entries, target]
+
+        buildHolidayPayFlags(reportEntries)
+        buildYearHolidayContext(reportEntries, { typicalDays: 5 })
+
+        const rollingFlag = target.validation.flags.find(
+            (f) => f.id === 'holiday_rate_below_rolling_avg'
+        )
+        expect(rollingFlag).toBeDefined()
+        expect(rollingFlag?.inputs?.mixedMonthsIncluded).toBe(1)
+        expect(target.validation.lowConfidence).toBe(true)
+        expect(target.holidayContext.hasBaseline).toBe(true)
+        expect(target.holidayContext.mixedMonthsIncluded).toBe(1)
+        expect(target.holidayContext.confidence.level).toBe('low')
+        expect(target.holidayContext.confidence.reasons).toContain(
+            'Includes 1 mixed work+holiday month'
+        )
+    })
+
+    it('preserves first mixed-target notice while keeping holidayContext reference pure', () => {
+        const entries = [
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 1,
+                parsedDate: new Date(2024, 0, 15),
+            }),
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 2,
+                parsedDate: new Date(2024, 1, 15),
+            }),
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 3,
+                parsedDate: new Date(2024, 2, 15),
+            }),
+        ]
+        const target = makeEntry({
+            basicUnits: 128,
+            basicRate: 12.5,
+            holidayUnits: 8,
+            holidayAmount: 72,
+            monthIndex: 4,
+            parsedDate: new Date(2024, 3, 15),
+        })
+        const reportEntries = [...entries, target]
+
+        buildHolidayPayFlags(reportEntries)
+        buildYearHolidayContext(reportEntries, { typicalDays: 5 })
+
+        const mixedNotice = target.validation.flags.find(
+            (f) => f.id === 'holiday_mixed_basic_holiday_pay'
+        )
+        expect(mixedNotice).toBeDefined()
+        expect(mixedNotice?.inputs?.mixedMonthsIncluded).toBe(1)
+        expect(target.validation.lowConfidence).toBe(true)
+        expect(target.holidayContext.hasBaseline).toBe(true)
+        expect(target.holidayContext.mixedMonthsIncluded).toBe(0)
+        expect(target.holidayContext.confidence.level).toBe('medium')
+    })
+
+    it('keeps insufficient-history notice and no-baseline context aligned across both passes', () => {
+        const entries = [
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 1,
+                parsedDate: new Date(2024, 0, 15),
+            }),
+            makeEntry({
+                basicUnits: 160,
+                basicRate: 12.5,
+                monthIndex: 2,
+                parsedDate: new Date(2024, 1, 15),
+            }),
+        ]
+        const holidayEntry = makeEntry({
+            basicUnits: 0,
+            basicRate: null,
+            basicAmount: 0,
+            holidayUnits: 8,
+            holidayAmount: 80,
+            monthIndex: 3,
+            parsedDate: new Date(2024, 2, 15),
+        })
+        const reportEntries = [...entries, holidayEntry]
+
+        buildHolidayPayFlags(reportEntries)
+        buildYearHolidayContext(reportEntries, { typicalDays: 5 })
+
+        expect(holidayEntry.validation.lowConfidence).toBe(true)
+        expect(
+            holidayEntry.validation.flags.some(
+                (f) => f.id === 'holiday_reference_insufficient_history'
+            )
+        ).toBe(true)
+        expect(
+            holidayEntry.validation.flags.some(
+                (f) => f.id === 'holiday_rate_below_rolling_avg'
+            )
+        ).toBe(false)
+        expect(
+            holidayEntry.validation.flags.some(
+                (f) => f.id === 'holiday_mixed_basic_holiday_pay'
+            )
+        ).toBe(false)
+        expect(holidayEntry.holidayContext).toMatchObject({
+            hasBaseline: false,
+            typicalDays: 5,
+        })
+    })
+})
+
 describe('isReferenceEligible — statutory pay titles', () => {
     it('returns false when basic.units is null (not zero)', () => {
         const entry = makeEntry({ basicUnits: 160, basicRate: 14.5 })

--- a/tests/report_view_model.test.mjs
+++ b/tests/report_view_model.test.mjs
@@ -579,6 +579,7 @@ describe('buildSummaryViewModel', () => {
         expect(viewModel.contractTypeMismatchWarning).toBe(
             'Worker type mismatch'
         )
+        expect(viewModel.thresholdStalenessNotice).toBeNull()
         expect(viewModel.globalCoverageNotice).toBeTruthy()
         expect(viewModel.globalCoverageNotice?.affectedYears).toEqual([
             '2024/25',
@@ -635,6 +636,49 @@ describe('buildSummaryViewModel', () => {
         expect(ruleSnapshotRow?.displayValue).toBe(
             'Rules 2026-03-30 · Thresholds 2026-03-30'
         )
+    })
+
+    it('shows threshold staleness notice only after April 6 with new-tax-year fallback periods', () => {
+        const { context, meta } = buildStageTwoContext()
+        context.thresholdStaleness = {
+            reportRunDateIso: '2026-04-12T12:00:00.000Z',
+            runTaxYearLabel: '2026/27',
+            fallbackTaxYearLabels: ['2025/26'],
+            affectedPeriods: ['10 Apr 2026'],
+            hasRunTaxYearFallback: true,
+        }
+
+        const viewModel = buildSummaryViewModel(context, meta)
+
+        expect(viewModel.thresholdStalenessNotice).toBeTruthy()
+        expect(viewModel.thresholdStalenessNotice?.message).toContain(
+            'Threshold data for 2026/27 has not been updated.'
+        )
+    })
+
+    it('keeps threshold staleness notice silent before/at April 6 or without run-year fallback periods', () => {
+        const { context, meta } = buildStageTwoContext()
+        context.thresholdStaleness = {
+            reportRunDateIso: '2026-04-06T12:00:00.000Z',
+            runTaxYearLabel: '2026/27',
+            fallbackTaxYearLabels: ['2025/26'],
+            affectedPeriods: ['10 Apr 2026'],
+            hasRunTaxYearFallback: true,
+        }
+
+        const onBoundaryViewModel = buildSummaryViewModel(context, meta)
+        expect(onBoundaryViewModel.thresholdStalenessNotice).toBeNull()
+
+        context.thresholdStaleness = {
+            reportRunDateIso: '2026-04-12T12:00:00.000Z',
+            runTaxYearLabel: '2026/27',
+            fallbackTaxYearLabels: ['2025/26'],
+            affectedPeriods: [],
+            hasRunTaxYearFallback: false,
+        }
+
+        const noFallbackViewModel = buildSummaryViewModel(context, meta)
+        expect(noFallbackViewModel.thresholdStalenessNotice).toBeNull()
     })
 
     it('omits holiday coverage notices for salary-only years', () => {

--- a/tests/threshold_staleness_check.test.mjs
+++ b/tests/threshold_staleness_check.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const scriptPath = path.resolve(
+    __dirname,
+    '../scripts/check-threshold-staleness.mjs'
+)
+
+/**
+ * @param {string} dateValue
+ */
+function runCheck(dateValue) {
+    return spawnSync(process.execPath, [scriptPath], {
+        env: {
+            ...process.env,
+            THRESHOLD_CHECK_TODAY: dateValue,
+        },
+        encoding: 'utf8',
+    })
+}
+
+describe('check-threshold-staleness script', () => {
+    it('warns (exit 0) before April 1 when THRESHOLDS_VERSION is stale for the cycle', () => {
+        const result = runCheck('2027-03-20')
+        expect(result.status).toBe(0)
+        expect(`${result.stdout}${result.stderr}`).toContain('WARNING')
+    })
+
+    it('fails (exit 1) on/after April 1 when THRESHOLDS_VERSION is stale for the cycle', () => {
+        const result = runCheck('2027-04-01')
+        expect(result.status).toBe(1)
+        expect(`${result.stdout}${result.stderr}`).toContain('ERROR')
+    })
+
+    it('fails when THRESHOLD_CHECK_TODAY is invalid', () => {
+        const result = runCheck('not-a-date')
+        expect(result.status).toBe(1)
+        expect(`${result.stdout}${result.stderr}`).toContain(
+            'Invalid THRESHOLD_CHECK_TODAY'
+        )
+    })
+})

--- a/tests/threshold_staleness_check.test.mjs
+++ b/tests/threshold_staleness_check.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { THRESHOLDS_VERSION } from '../pwa/src/report/uk_thresholds.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -23,15 +24,23 @@ function runCheck(dateValue) {
     })
 }
 
+const thresholdsVersionYear = Number.parseInt(
+    String(THRESHOLDS_VERSION).slice(0, 4),
+    10
+)
+const staleCycleYear = thresholdsVersionYear + 1
+const staleCyclePreCutoffDate = `${staleCycleYear}-03-20`
+const staleCycleCutoffDate = `${staleCycleYear}-04-01`
+
 describe('check-threshold-staleness script', () => {
     it('warns (exit 0) before April 1 when THRESHOLDS_VERSION is stale for the cycle', () => {
-        const result = runCheck('2027-03-20')
+        const result = runCheck(staleCyclePreCutoffDate)
         expect(result.status).toBe(0)
         expect(`${result.stdout}${result.stderr}`).toContain('WARNING')
     })
 
     it('fails (exit 1) on/after April 1 when THRESHOLDS_VERSION is stale for the cycle', () => {
-        const result = runCheck('2027-04-01')
+        const result = runCheck(staleCycleCutoffDate)
         expect(result.status).toBe(1)
         expect(`${result.stdout}${result.stderr}`).toContain('ERROR')
     })

--- a/tests/uk_thresholds.test.mjs
+++ b/tests/uk_thresholds.test.mjs
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import {
     formatTaxYearLabelFromStartYear,
+    getLatestConfiguredThresholdTaxYearStart,
     getIncomeTaxBandsForRegion,
     getPayPeriodIndexForDate,
     getPayPeriodsPerYear,
     getPeriodizedAnnualAmount,
+    getThresholdStalenessStatus,
     getTaxYearStartYearFromDate,
     getTaxYearStartYearFromKey,
     getTaxYearThresholdsByStartYear,
     getTaxYearThresholdsForContext,
+    parseThresholdsVersionDate,
     parsePayeTaxCode,
     resolveTaxYearThresholdsForContext,
     TAX_YEAR_THRESHOLDS,
@@ -441,5 +444,54 @@ describe('getTaxYearThresholdsForContext', () => {
         const thresholds = getTaxYearThresholdsForContext(new Date(2028, 4, 15))
         // Should return 2026 thresholds as fallback
         expect(thresholds).not.toBeNull()
+    })
+})
+
+describe('threshold staleness policy', () => {
+    it('parses thresholds version date in YYYY-MM-DD format', () => {
+        const parsed = parseThresholdsVersionDate('2026-04-04')
+        expect(parsed).toBeInstanceOf(Date)
+        expect(parsed?.getFullYear()).toBe(2026)
+        expect(parsed?.getMonth()).toBe(3)
+        expect(parsed?.getDate()).toBe(4)
+    })
+
+    it('returns null for invalid thresholds version date strings', () => {
+        expect(parseThresholdsVersionDate('2026/04/04')).toBeNull()
+        expect(parseThresholdsVersionDate('invalid')).toBeNull()
+        expect(parseThresholdsVersionDate('2026-02-30')).toBeNull()
+    })
+
+    it('returns the latest configured threshold tax year start', () => {
+        expect(getLatestConfiguredThresholdTaxYearStart()).toBe(2026)
+    })
+
+    it('returns warning before April 1 when thresholds version is stale for the year', () => {
+        const status = getThresholdStalenessStatus(
+            new Date(2027, 2, 20),
+            '2026-04-04'
+        )
+        expect(status.status).toBe('warning')
+    })
+
+    it('returns expired on/after April 1 when thresholds version is stale for the year', () => {
+        const onCutoff = getThresholdStalenessStatus(
+            new Date(2027, 3, 1),
+            '2026-04-04'
+        )
+        expect(onCutoff.status).toBe('expired')
+    })
+
+    it('returns ok when thresholds version has been refreshed on/after April 1 in current year', () => {
+        const status = getThresholdStalenessStatus(
+            new Date(2027, 3, 12),
+            '2027-04-02'
+        )
+        expect(status.status).toBe('ok')
+    })
+
+    it('returns invalid-thresholds-version for malformed version', () => {
+        const status = getThresholdStalenessStatus(new Date(2027, 3, 12), 'bad')
+        expect(status.status).toBe('invalid-thresholds-version')
     })
 })


### PR DESCRIPTION
Fix various perf-issues - Closes #49 
Add notices for stale threshold data, both in build and UI reports - Closes #34, Closes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated threshold-staleness detection with a CLI check to flag outdated tax threshold data.

* **Improvements**
  * Report notices unified across HTML/PDF/summary/year outputs; styling and spacing refined.
  * Threshold-staleness notices and richer misc-payment footnotes (now include year) added to report context and view models.
  * Precomputed coverage data to stabilize year/summary rendering and exports.
  * Holiday-reference runtime introduced to improve holiday calculations and confidence handling.

* **Tests**
  * Added tests for threshold staleness, holiday pipeline behavior, and view-model notice logic.

* **Chores**
  * Build updated to run threshold check before PWA build; package metadata and linting config updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->